### PR TITLE
Feat: 리뷰 v2 api 구현

### DIFF
--- a/src/main/generated/ssu/eatssu/domain/menu/entity/QMenu.java
+++ b/src/main/generated/ssu/eatssu/domain/menu/entity/QMenu.java
@@ -28,6 +28,8 @@ public class QMenu extends EntityPathBase<Menu> {
 
     public final BooleanPath isDiscontinued = createBoolean("isDiscontinued");
 
+    public final NumberPath<Integer> likeCount = createNumber("likeCount", Integer.class);
+
     public final ListPath<MealMenu, QMealMenu> mealMenus = this.<MealMenu, QMealMenu>createList("mealMenus", MealMenu.class, QMealMenu.class, PathInits.DIRECT2);
 
     public final StringPath name = createString("name");
@@ -37,6 +39,8 @@ public class QMenu extends EntityPathBase<Menu> {
     public final EnumPath<ssu.eatssu.domain.restaurant.entity.Restaurant> restaurant = createEnum("restaurant", ssu.eatssu.domain.restaurant.entity.Restaurant.class);
 
     public final ssu.eatssu.domain.review.entity.QReviews reviews;
+
+    public final NumberPath<Integer> unlikeCount = createNumber("unlikeCount", Integer.class);
 
     public QMenu(String variable) {
         this(Menu.class, forVariable(variable), INITS);

--- a/src/main/generated/ssu/eatssu/domain/review/entity/QReview.java
+++ b/src/main/generated/ssu/eatssu/domain/review/entity/QReview.java
@@ -31,10 +31,14 @@ public class QReview extends EntityPathBase<Review> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
+    public final ssu.eatssu.domain.menu.entity.QMeal meal;
+
     public final ssu.eatssu.domain.menu.entity.QMenu menu;
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> modifiedDate = _super.modifiedDate;
+
+    public final NumberPath<Integer> rating = createNumber("rating", Integer.class);
 
     public final ssu.eatssu.domain.rating.entity.QRatings ratings;
 
@@ -60,6 +64,7 @@ public class QReview extends EntityPathBase<Review> {
 
     public QReview(Class<? extends Review> type, PathMetadata metadata, PathInits inits) {
         super(type, metadata, inits);
+        this.meal = inits.isInitialized("meal") ? new ssu.eatssu.domain.menu.entity.QMeal(forProperty("meal")) : null;
         this.menu = inits.isInitialized("menu") ? new ssu.eatssu.domain.menu.entity.QMenu(forProperty("menu"), inits.get("menu")) : null;
         this.ratings = inits.isInitialized("ratings") ? new ssu.eatssu.domain.rating.entity.QRatings(forProperty("ratings")) : null;
         this.user = inits.isInitialized("user") ? new ssu.eatssu.domain.user.entity.QUser(forProperty("user")) : null;

--- a/src/main/generated/ssu/eatssu/domain/review/entity/QReview.java
+++ b/src/main/generated/ssu/eatssu/domain/review/entity/QReview.java
@@ -44,6 +44,8 @@ public class QReview extends EntityPathBase<Review> {
 
     public final ListPath<ReviewImage, QReviewImage> reviewImages = this.<ReviewImage, QReviewImage>createList("reviewImages", ReviewImage.class, QReviewImage.class, PathInits.DIRECT2);
 
+    public final ListPath<ReviewMenuLike, QReviewMenuLike> reviewMenuLikes = this.<ReviewMenuLike, QReviewMenuLike>createList("reviewMenuLikes", ReviewMenuLike.class, QReviewMenuLike.class, PathInits.DIRECT2);
+
     public final ssu.eatssu.domain.user.entity.QUser user;
 
     public QReview(String variable) {

--- a/src/main/generated/ssu/eatssu/domain/review/entity/QReview.java
+++ b/src/main/generated/ssu/eatssu/domain/review/entity/QReview.java
@@ -35,6 +35,8 @@ public class QReview extends EntityPathBase<Review> {
 
     public final ssu.eatssu.domain.menu.entity.QMenu menu;
 
+    public final ListPath<ReviewMenuLike, QReviewMenuLike> menuLikes = this.<ReviewMenuLike, QReviewMenuLike>createList("menuLikes", ReviewMenuLike.class, QReviewMenuLike.class, PathInits.DIRECT2);
+
     //inherited
     public final DateTimePath<java.time.LocalDateTime> modifiedDate = _super.modifiedDate;
 
@@ -43,8 +45,6 @@ public class QReview extends EntityPathBase<Review> {
     public final ssu.eatssu.domain.rating.entity.QRatings ratings;
 
     public final ListPath<ReviewImage, QReviewImage> reviewImages = this.<ReviewImage, QReviewImage>createList("reviewImages", ReviewImage.class, QReviewImage.class, PathInits.DIRECT2);
-
-    public final ListPath<ReviewMenuLike, QReviewMenuLike> reviewMenuLikes = this.<ReviewMenuLike, QReviewMenuLike>createList("reviewMenuLikes", ReviewMenuLike.class, QReviewMenuLike.class, PathInits.DIRECT2);
 
     public final ssu.eatssu.domain.user.entity.QUser user;
 

--- a/src/main/generated/ssu/eatssu/domain/review/entity/QReviewMenuLike.java
+++ b/src/main/generated/ssu/eatssu/domain/review/entity/QReviewMenuLike.java
@@ -1,0 +1,56 @@
+package ssu.eatssu.domain.review.entity;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QReviewMenuLike is a Querydsl query type for ReviewMenuLike
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QReviewMenuLike extends EntityPathBase<ReviewMenuLike> {
+
+    private static final long serialVersionUID = -1523380939L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QReviewMenuLike reviewMenuLike = new QReviewMenuLike("reviewMenuLike");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath isLike = createBoolean("isLike");
+
+    public final ssu.eatssu.domain.menu.entity.QMenu menu;
+
+    public final QReview review;
+
+    public QReviewMenuLike(String variable) {
+        this(ReviewMenuLike.class, forVariable(variable), INITS);
+    }
+
+    public QReviewMenuLike(Path<? extends ReviewMenuLike> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QReviewMenuLike(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QReviewMenuLike(PathMetadata metadata, PathInits inits) {
+        this(ReviewMenuLike.class, metadata, inits);
+    }
+
+    public QReviewMenuLike(Class<? extends ReviewMenuLike> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.menu = inits.isInitialized("menu") ? new ssu.eatssu.domain.menu.entity.QMenu(forProperty("menu"), inits.get("menu")) : null;
+        this.review = inits.isInitialized("review") ? new QReview(forProperty("review"), inits.get("review")) : null;
+    }
+
+}
+

--- a/src/main/java/ssu/eatssu/domain/auth/infrastructure/SecurityConfig.java
+++ b/src/main/java/ssu/eatssu/domain/auth/infrastructure/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/", "/oauths/kakao", "/oauths/apple", "/menus/**", "/meals/**", "/admin/login",
-            "/reviews", "/reviews/menus/**", "/reviews/meals/**"
+            "/reviews", "/reviews/menus/**", "/reviews/meals/**", "/v2/reviews/statistics", "/v2/reviews"
     };
 
     private static final String[] ADMIN_PAGE_LIST = {

--- a/src/main/java/ssu/eatssu/domain/menu/entity/Menu.java
+++ b/src/main/java/ssu/eatssu/domain/menu/entity/Menu.java
@@ -100,4 +100,22 @@ public class Menu {
     public void decreaseUnlikeCount() {
         unlikeCount--;
     }
+
+    public void changeLikeStatus(Boolean isLike) {
+        if (isLike) {
+            decreaseUnlikeCount();
+            increaseLikeCount();
+        } else {
+            decreaseLikeCount();
+            increaseUnlikeCount();
+        }
+    }
+
+    public void adjustLikeCount(int count, Boolean isLike) {
+        if (isLike) {
+            this.likeCount += count;
+        } else {
+            this.unlikeCount += count;
+        }
+    }
 }

--- a/src/main/java/ssu/eatssu/domain/menu/entity/Menu.java
+++ b/src/main/java/ssu/eatssu/domain/menu/entity/Menu.java
@@ -111,11 +111,11 @@ public class Menu {
         }
     }
 
-    public void adjustLikeCount(int count, Boolean isLike) {
+    public void cancelLike(Boolean isLike) {
         if (isLike) {
-            this.likeCount += count;
+            decreaseLikeCount();
         } else {
-            this.unlikeCount += count;
+            decreaseUnlikeCount();
         }
     }
 }

--- a/src/main/java/ssu/eatssu/domain/menu/entity/Menu.java
+++ b/src/main/java/ssu/eatssu/domain/menu/entity/Menu.java
@@ -28,6 +28,7 @@ public class Menu {
     @Enumerated(EnumType.STRING)
     private Restaurant restaurant;
 
+    // TODO : 삭제되어야 함
     @Embedded
     private Reviews reviews = new Reviews();
 
@@ -39,6 +40,12 @@ public class Menu {
     private MenuCategory category;
 
     private boolean isDiscontinued = false;
+
+    @Column(name = "like_count")
+    private Integer likeCount = 0;
+
+    @Column(name = "unlike_count")
+    private Integer unlikeCount = 0;
 
     private Menu(String name, Restaurant restaurant, Integer price, MenuCategory category) {
         this.name = name;
@@ -76,5 +83,21 @@ public class Menu {
 
     public boolean isContinued() {
         return !this.isDiscontinued;
+    }
+
+    public void increaseLikeCount() {
+        likeCount++;
+    }
+
+    public void increaseUnlikeCount() {
+        unlikeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        likeCount--;
+    }
+
+    public void decreaseUnlikeCount() {
+        unlikeCount--;
     }
 }

--- a/src/main/java/ssu/eatssu/domain/menu/persistence/MealMenuRepository.java
+++ b/src/main/java/ssu/eatssu/domain/menu/persistence/MealMenuRepository.java
@@ -3,6 +3,7 @@ package ssu.eatssu.domain.menu.persistence;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import ssu.eatssu.domain.menu.entity.Meal;
 import ssu.eatssu.domain.menu.entity.MealMenu;
 import ssu.eatssu.domain.menu.entity.Menu;
@@ -10,4 +11,10 @@ import ssu.eatssu.domain.menu.entity.Menu;
 public interface MealMenuRepository extends JpaRepository<MealMenu, Long> {
     @Query("SELECT mm.menu FROM MealMenu mm WHERE mm.meal IN :meals")
     List<Menu> findMenusByMeals(List<Meal> meals);
+
+    @Query("SELECT mm.menu.id FROM MealMenu mm WHERE mm.meal.id = :mealId")
+    List<Long> findMenuIdsByMealId(@Param("mealId") Long mealId);
+
+    @Query("SELECT DISTINCT mm.meal.id FROM MealMenu mm WHERE mm.menu.id IN :menuIds")
+    List<Long> findMealIdsByMenuIds(@Param("menuIds") List<Long> menuIds);
 }

--- a/src/main/java/ssu/eatssu/domain/menu/persistence/MealMenuRepository.java
+++ b/src/main/java/ssu/eatssu/domain/menu/persistence/MealMenuRepository.java
@@ -1,7 +1,13 @@
 package ssu.eatssu.domain.menu.persistence;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import ssu.eatssu.domain.menu.entity.Meal;
 import ssu.eatssu.domain.menu.entity.MealMenu;
+import ssu.eatssu.domain.menu.entity.Menu;
 
 public interface MealMenuRepository extends JpaRepository<MealMenu, Long> {
+    @Query("SELECT mm.menu FROM MealMenu mm WHERE mm.meal IN :meals")
+    List<Menu> findMenusByMeals(List<Meal> meals);
 }

--- a/src/main/java/ssu/eatssu/domain/menu/persistence/MealRepository.java
+++ b/src/main/java/ssu/eatssu/domain/menu/persistence/MealRepository.java
@@ -11,4 +11,6 @@ import java.util.List;
 public interface MealRepository extends JpaRepository<Meal, Long> {
 
     List<Meal> findAllByDateAndTimePartAndRestaurant(Date date, TimePart timePart, Restaurant restaurant);
+
+    List<Meal> findByRestaurant(Restaurant restaurant);
 }

--- a/src/main/java/ssu/eatssu/domain/review/dto/CreateMealReviewRequest.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/CreateMealReviewRequest.java
@@ -1,0 +1,41 @@
+package ssu.eatssu.domain.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import ssu.eatssu.domain.menu.entity.Meal;
+import ssu.eatssu.domain.review.entity.Review;
+import ssu.eatssu.domain.review.entity.ReviewImage;
+import ssu.eatssu.domain.user.entity.User;
+
+@Schema(title = "리뷰 작성")
+@Getter
+@AllArgsConstructor
+public class CreateMealReviewRequest {
+    @Schema(description = "식단 식별자", example = "123")
+    private Long mealId;
+    @Schema(description = "평점", example = "4")
+    private Integer rating;
+    private List<MenuLikeRequest> menuLikes;
+    @Schema(description = "한줄평", example = "맛있어용")
+    private String content;
+    @Schema(description = "리뷰 이미지 url 리스트", example = "[\"imgurl1\", \"imgurl2\"]")
+    private List<String> imageUrls;
+
+    public Review toReviewEntity(User user, Meal meal) {
+        return Review.builder()
+                .user(user)
+                .meal(meal)
+                .content(content)
+                .rating(rating)
+                .build();
+    }
+
+    public List<ReviewImage> createReviewImages(Review review) {
+        return imageUrls.stream()
+                .map(imageUrl -> new ReviewImage(review, imageUrl))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/ssu/eatssu/domain/review/dto/MealReviewResponse.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/MealReviewResponse.java
@@ -1,0 +1,71 @@
+package ssu.eatssu.domain.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import ssu.eatssu.domain.review.entity.Review;
+
+@AllArgsConstructor
+@Builder
+@Schema(title = "리뷰 상세")
+@Getter
+public class MealReviewResponse {
+    @Schema(description = "리뷰 식별자", example = "123")
+    Long reviewId;
+
+    @Schema(description = "작성자 식별자", example = "123")
+    Long writerId;
+
+    @Schema(description = "본인 글인지 여부(true/false)", example = "true")
+    Boolean isWriter;
+
+    @Schema(description = "작성자 닉네임", example = "숭시리시리")
+    private String writerNickname;
+
+    @Schema(description = "평점", example = "4")
+    private Integer rating;
+
+    @Schema(description = "리뷰 작성 날짜(format = yyyy-MM-dd)", example = "2023-04-07")
+    private LocalDate writtenAt;
+
+    @Schema(description = "리뷰 내용", example = "맛있습니당")
+    private String content;
+
+    @Schema(description = "리뷰 이미지 url 리스트", example = "[\"imgurl1\", \"imgurl2\"]")
+    private List<String> imageUrls;
+
+    public static MealReviewResponse from(Review review, Long userId) {
+        List<String> imageUrls = new ArrayList<>();
+        review.getReviewImages().forEach(i -> imageUrls.add(i.getImageUrl()));
+
+        MealReviewResponseBuilder builder = MealReviewResponse.builder()
+                .reviewId(review.getId())
+                .rating(review.getRating())
+                .writtenAt(review.getCreatedDate().toLocalDate())
+                .content(review.getContent())
+                .imageUrls(imageUrls);
+
+        if (review.getUser() == null) {
+            return builder.writerId(null)
+                    .writerNickname("알 수 없음")
+                    .isWriter(false)
+                    .build();
+        }
+
+        if (review.getUser().getId().equals(userId)) {
+            return builder.writerId(review.getUser().getId())
+                    .writerNickname(review.getUser().getNickname())
+                    .isWriter(true)
+                    .build();
+        }
+
+        return builder.writerId(review.getUser().getId())
+                .writerNickname(review.getUser().getNickname())
+                .isWriter(false)
+                .build();
+    }
+}

--- a/src/main/java/ssu/eatssu/domain/review/dto/MealReviewResponse.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/MealReviewResponse.java
@@ -43,6 +43,12 @@ public class MealReviewResponse {
     @Schema(description = "좋아요한 메뉴명 리스트", example = "[\"메뉴1\", \"메뉴2\"]")
     private List<String> likedMenuNames;
 
+    @Schema(description = "본인이 이 리뷰에 좋아요를 눌렀는지 여부(true/false)", example = "true")
+    private Boolean isLikedByUser;
+
+    @Schema(description = "리뷰 좋아요 개수", example = "10")
+    private Integer likeCount;
+
     public static MealReviewResponse from(Review review, Long userId) {
         List<String> imageUrls = new ArrayList<>();
         review.getReviewImages().forEach(i -> imageUrls.add(i.getImageUrl()));
@@ -52,13 +58,18 @@ public class MealReviewResponse {
                 .map(like -> like.getMenu().getName())
                 .collect(Collectors.toList());
 
+        boolean isLikedByUser = (userId != null) && review.getReviewLikes().stream()
+                .anyMatch(like -> like.getUser().getId().equals(userId));
+
         MealReviewResponseBuilder builder = MealReviewResponse.builder()
                 .reviewId(review.getId())
                 .rating(review.getRating())
                 .writtenAt(review.getCreatedDate().toLocalDate())
                 .content(review.getContent())
                 .imageUrls(imageUrls)
-                .likedMenuNames(likedMenuNames);
+                .likedMenuNames(likedMenuNames)
+                .isLikedByUser(isLikedByUser)
+                .likeCount(review.getReviewLikes().size());
 
         if (review.getUser() == null) {
             return builder.writerId(null)

--- a/src/main/java/ssu/eatssu/domain/review/dto/MealReviewResponse.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/MealReviewResponse.java
@@ -4,10 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import ssu.eatssu.domain.review.entity.Review;
+import ssu.eatssu.domain.review.entity.ReviewMenuLike;
 
 @AllArgsConstructor
 @Builder
@@ -38,16 +40,25 @@ public class MealReviewResponse {
     @Schema(description = "리뷰 이미지 url 리스트", example = "[\"imgurl1\", \"imgurl2\"]")
     private List<String> imageUrls;
 
+    @Schema(description = "좋아요한 메뉴명 리스트", example = "[\"메뉴1\", \"메뉴2\"]")
+    private List<String> likedMenuNames;
+
     public static MealReviewResponse from(Review review, Long userId) {
         List<String> imageUrls = new ArrayList<>();
         review.getReviewImages().forEach(i -> imageUrls.add(i.getImageUrl()));
+
+        List<String> likedMenuNames = review.getMenuLikes().stream()
+                .filter(ReviewMenuLike::getIsLike)
+                .map(like -> like.getMenu().getName())
+                .collect(Collectors.toList());
 
         MealReviewResponseBuilder builder = MealReviewResponse.builder()
                 .reviewId(review.getId())
                 .rating(review.getRating())
                 .writtenAt(review.getCreatedDate().toLocalDate())
                 .content(review.getContent())
-                .imageUrls(imageUrls);
+                .imageUrls(imageUrls)
+                .likedMenuNames(likedMenuNames);
 
         if (review.getUser() == null) {
             return builder.writerId(null)

--- a/src/main/java/ssu/eatssu/domain/review/dto/MealReviewResponse.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/MealReviewResponse.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import ssu.eatssu.domain.review.entity.Review;
 import ssu.eatssu.domain.review.entity.ReviewMenuLike;
+import ssu.eatssu.domain.user.util.UserAliasUtil;
 
 @AllArgsConstructor
 @Builder
@@ -49,6 +50,9 @@ public class MealReviewResponse {
     @Schema(description = "리뷰 좋아요 개수", example = "10")
     private Integer likeCount;
 
+    @Schema(description = "별칭", example = "미슈테리 미식가")
+    private String alias;
+
     public static MealReviewResponse from(Review review, Long userId) {
         List<String> imageUrls = new ArrayList<>();
         review.getReviewImages().forEach(i -> imageUrls.add(i.getImageUrl()));
@@ -61,6 +65,9 @@ public class MealReviewResponse {
         boolean isLikedByUser = (userId != null) && review.getReviewLikes().stream()
                 .anyMatch(like -> like.getUser().getId().equals(userId));
 
+        String alias = (review.getUser() != null) ? UserAliasUtil.getUserAlias(review.getUser(),
+                review.getUser().getReviews()) : "알 수 없음";
+
         MealReviewResponseBuilder builder = MealReviewResponse.builder()
                 .reviewId(review.getId())
                 .rating(review.getRating())
@@ -69,7 +76,8 @@ public class MealReviewResponse {
                 .imageUrls(imageUrls)
                 .likedMenuNames(likedMenuNames)
                 .isLikedByUser(isLikedByUser)
-                .likeCount(review.getReviewLikes().size());
+                .likeCount(review.getReviewLikes().size())
+                .alias(alias);
 
         if (review.getUser() == null) {
             return builder.writerId(null)

--- a/src/main/java/ssu/eatssu/domain/review/dto/MenuLikeRequest.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/MenuLikeRequest.java
@@ -1,0 +1,15 @@
+package ssu.eatssu.domain.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(title = "메뉴 좋아요/싫어요 리뷰")
+@Getter
+@AllArgsConstructor
+public class MenuLikeRequest {
+    @Schema(description = "메뉴 식별자", example = "123")
+    private Long menuId;
+    @Schema(description = "좋아요 or 싫어요", example = "좋아요 : true or 싫어요 : false")
+    private Boolean isLike;
+}

--- a/src/main/java/ssu/eatssu/domain/review/dto/RestaurantReviewResponse.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/RestaurantReviewResponse.java
@@ -1,0 +1,27 @@
+package ssu.eatssu.domain.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(title = "특정 식당 모든 리뷰 정보(평점 등등)")
+@Getter
+@AllArgsConstructor
+@Builder
+public class RestaurantReviewResponse {
+    @Schema(description = "리뷰 개수", example = "15")
+    private Integer totalReviewCount;
+
+    @Schema(description = "별점 별 개수")
+    private ReviewRatingCount reviewRatingCount;
+
+    @Schema(description = "리뷰 평점", example = "4.4")
+    private Double mainRating;
+
+    @Schema(description = "좋아요 개수", example = "15")
+    private Integer likeCount;
+
+    @Schema(description = "싫어요 개수", example = "15")
+    private Integer unlikeCount;
+}

--- a/src/main/java/ssu/eatssu/domain/review/dto/ReviewRatingCount.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/ReviewRatingCount.java
@@ -1,6 +1,10 @@
 package ssu.eatssu.domain.review.dto;
 
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import ssu.eatssu.domain.review.entity.Review;
 
 //COMMENT: 더 좋은 매개변수 명이 있을 것 같은데 제 머리로는 이게 한계입니다... 멋진 변수명으로 바꿔주세요
 public record ReviewRatingCount(long oneStarCount, long twoStarCount, long threeStarCount, long fourStarCount,
@@ -9,7 +13,10 @@ public record ReviewRatingCount(long oneStarCount, long twoStarCount, long three
     public ReviewRatingCount {
     }
 
-    public static ReviewRatingCount from(Map<Integer, Long> ratingDistribution) {
+    public static ReviewRatingCount from(List<Review> reviews) {
+        Map<Integer, Long> ratingDistribution = reviews.stream()
+                .collect(Collectors.groupingBy(Review::getRating, LinkedHashMap::new, Collectors.counting()));
+
         return new ReviewRatingCount(
                 ratingDistribution.getOrDefault(1, 0L),
                 ratingDistribution.getOrDefault(2, 0L),

--- a/src/main/java/ssu/eatssu/domain/review/dto/ReviewRatingCount.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/ReviewRatingCount.java
@@ -1,9 +1,21 @@
 package ssu.eatssu.domain.review.dto;
 
+import java.util.Map;
+
 //COMMENT: 더 좋은 매개변수 명이 있을 것 같은데 제 머리로는 이게 한계입니다... 멋진 변수명으로 바꿔주세요
 public record ReviewRatingCount(long oneStarCount, long twoStarCount, long threeStarCount, long fourStarCount,
                                 long fiveStarCount) {
 
     public ReviewRatingCount {
+    }
+
+    public static ReviewRatingCount from(Map<Integer, Long> ratingDistribution) {
+        return new ReviewRatingCount(
+                ratingDistribution.getOrDefault(1, 0L),
+                ratingDistribution.getOrDefault(2, 0L),
+                ratingDistribution.getOrDefault(3, 0L),
+                ratingDistribution.getOrDefault(4, 0L),
+                ratingDistribution.getOrDefault(5, 0L)
+        );
     }
 }

--- a/src/main/java/ssu/eatssu/domain/review/dto/UpdateMealReviewRequest.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/UpdateMealReviewRequest.java
@@ -1,0 +1,19 @@
+package ssu.eatssu.domain.review.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Schema(title = "리뷰 수정(글)")
+@Getter
+@AllArgsConstructor
+public class UpdateMealReviewRequest {
+    @Schema(description = "평점", example = "4")
+    private Integer rating;
+    private List<MenuLikeRequest> menuLikes;
+    @Max(150)
+    @Schema(description = "한줄평", example = "맛있어용")
+    private String content;
+}

--- a/src/main/java/ssu/eatssu/domain/review/entity/Review.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/Review.java
@@ -124,7 +124,7 @@ public class Review extends BaseTimeEntity {
         // 리뷰 요청 데이터에 없는 menu 항목이므로 삭제
         for (ReviewMenuLike remainingMenuLike : currentMenuLikes.values()) {
             this.menuLikes.remove(remainingMenuLike);
-            remainingMenuLike.getMenu().adjustLikeCount(-1, remainingMenuLike.getIsLike());
+            remainingMenuLike.getMenu().cancelLike(remainingMenuLike.getIsLike());
         }
     }
 

--- a/src/main/java/ssu/eatssu/domain/review/entity/Review.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/Review.java
@@ -54,7 +54,7 @@ public class Review extends BaseTimeEntity {
 
     @Builder.Default
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ReviewMenuLike> reviewMenuLikes = new ArrayList<>();
+    private List<ReviewMenuLike> menuLikes = new ArrayList<>();
 
     public void update(String content, Integer mainRate, Integer amountRate, Integer tasteRate) {
         this.content = content;
@@ -76,7 +76,7 @@ public class Review extends BaseTimeEntity {
 
     public void addReviewMenuLike(Menu menu, boolean isLike) {
         ReviewMenuLike reviewMenuLike = ReviewMenuLike.create(this, menu, isLike);
-        this.reviewMenuLikes.add(reviewMenuLike);
+        this.menuLikes.add(reviewMenuLike);
 
         if (isLike) {
             menu.increaseLikeCount();
@@ -86,7 +86,7 @@ public class Review extends BaseTimeEntity {
     }
 
     public void removeReviewMenuLike(ReviewMenuLike reviewMenuLike) {
-        this.reviewMenuLikes.remove(reviewMenuLike);
+        this.menuLikes.remove(reviewMenuLike);
 
         if (reviewMenuLike.getIsLike()) {
             reviewMenuLike.getMenu().decreaseLikeCount();
@@ -100,7 +100,7 @@ public class Review extends BaseTimeEntity {
         this.rating = rating;
 
         // 현재 menu like 상태를 menu를 기준으로 매핑
-        Map<Menu, ReviewMenuLike> currentMenuLikes = this.reviewMenuLikes.stream()
+        Map<Menu, ReviewMenuLike> currentMenuLikes = this.menuLikes.stream()
                 .collect(Collectors.toMap(ReviewMenuLike::getMenu, menuLike -> menuLike));
 
         for (Map.Entry<Menu, Boolean> entry : updatedMenuLikes.entrySet()) {
@@ -123,8 +123,15 @@ public class Review extends BaseTimeEntity {
 
         // 리뷰 요청 데이터에 없는 menu 항목이므로 삭제
         for (ReviewMenuLike remainingMenuLike : currentMenuLikes.values()) {
-            this.reviewMenuLikes.remove(remainingMenuLike);
+            this.menuLikes.remove(remainingMenuLike);
             remainingMenuLike.getMenu().adjustLikeCount(-1, remainingMenuLike.getIsLike());
         }
+    }
+
+    public void resetMenuLikes() {
+        for (ReviewMenuLike reviewMenuLike : this.menuLikes) {
+            reviewMenuLike.resetMenuLikeStatus();
+        }
+        this.menuLikes.clear();
     }
 }

--- a/src/main/java/ssu/eatssu/domain/review/entity/Review.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/Review.java
@@ -61,6 +61,7 @@ public class Review extends BaseTimeEntity {
         this.ratings = Ratings.of(mainRate, amountRate, tasteRate);
     }
 
+    // TODO : this.user가 null이면?
     public boolean isNotWrittenBy(User user) {
         return !this.user.equals(user);
     }
@@ -105,26 +106,18 @@ public class Review extends BaseTimeEntity {
 
         for (Map.Entry<Menu, Boolean> entry : updatedMenuLikes.entrySet()) {
             Menu menu = entry.getKey();
-            Boolean isLike = entry.getValue();
-
-            ReviewMenuLike currentMenuLike = currentMenuLikes.get(menu);
-
-            if (currentMenuLike == null) {
-                // 새롭게 추가된 menu like
-                this.addReviewMenuLike(menu, isLike);
-            } else if (!currentMenuLike.getIsLike().equals(isLike)) {
-                // 기존 menu like 수정
-                currentMenuLike.updateLike(isLike);
-                menu.changeLikeStatus(isLike);
+            Boolean newState = entry.getValue();
+            ReviewMenuLike existingReviewMenuLike = currentMenuLikes.get(menu);
+            if (existingReviewMenuLike == null) {
+                // 기존에 없는 메뉴이면 새롭게 추가
+                this.addReviewMenuLike(menu, newState);
+            } else {
+                // 기존에 있는 경우 : 상태가 다르면 업데이트
+                if (!existingReviewMenuLike.getIsLike().equals(newState)) {
+                    existingReviewMenuLike.updateLike(newState);
+                    menu.changeLikeStatus(newState);
+                }
             }
-            // 수정 후 map에서 제거(나머지는 삭제 대상)
-            currentMenuLikes.remove(menu);
-        }
-
-        // 리뷰 요청 데이터에 없는 menu 항목이므로 삭제
-        for (ReviewMenuLike remainingMenuLike : currentMenuLikes.values()) {
-            this.menuLikes.remove(remainingMenuLike);
-            remainingMenuLike.getMenu().cancelLike(remainingMenuLike.getIsLike());
         }
     }
 

--- a/src/main/java/ssu/eatssu/domain/review/entity/Review.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/Review.java
@@ -56,6 +56,9 @@ public class Review extends BaseTimeEntity {
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewMenuLike> menuLikes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewLike> reviewLikes = new ArrayList<>();
+
     public void update(String content, Integer mainRate, Integer amountRate, Integer tasteRate) {
         this.content = content;
         this.ratings = Ratings.of(mainRate, amountRate, tasteRate);

--- a/src/main/java/ssu/eatssu/domain/review/entity/Review.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/Review.java
@@ -46,8 +46,13 @@ public class Review extends BaseTimeEntity {
     @JoinColumn(name = "meal_id")
     private Meal meal;
 
+    @Builder.Default
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewImage> reviewImages = new ArrayList<>();
+
+    @Builder.Default
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewMenuLike> reviewMenuLikes = new ArrayList<>();
 
     public void update(String content, Integer mainRate, Integer amountRate, Integer tasteRate) {
         this.content = content;
@@ -62,4 +67,29 @@ public class Review extends BaseTimeEntity {
         this.user = null;
     }
 
+    public void addReviewImage(String imageUrl) {
+        ReviewImage reviewImage = new ReviewImage(this, imageUrl);
+        this.reviewImages.add(reviewImage);
+    }
+
+    public void addReviewMenuLike(Menu menu, boolean isLike) {
+        ReviewMenuLike reviewMenuLike = ReviewMenuLike.create(this, menu, isLike);
+        this.reviewMenuLikes.add(reviewMenuLike);
+
+        if (isLike) {
+            menu.increaseLikeCount();
+        } else {
+            menu.increaseUnlikeCount();
+        }
+    }
+
+    public void removeReviewMenuLike(ReviewMenuLike reviewMenuLike) {
+        this.reviewMenuLikes.remove(reviewMenuLike);
+
+        if (reviewMenuLike.getIsLike()) {
+            reviewMenuLike.getMenu().decreaseLikeCount();
+        } else {
+            reviewMenuLike.getMenu().decreaseUnlikeCount();
+        }
+    }
 }

--- a/src/main/java/ssu/eatssu/domain/review/entity/Review.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/Review.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor

--- a/src/main/java/ssu/eatssu/domain/review/entity/Review.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/Review.java
@@ -2,6 +2,7 @@ package ssu.eatssu.domain.review.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import ssu.eatssu.domain.menu.entity.Meal;
 import ssu.eatssu.domain.menu.entity.Menu;
 import ssu.eatssu.domain.rating.entity.Ratings;
 import ssu.eatssu.domain.user.entity.BaseTimeEntity;
@@ -25,16 +26,24 @@ public class Review extends BaseTimeEntity {
 
     private String content;
 
+    // TODO : 삭제되어야 함
     @Embedded
     private Ratings ratings;
+
+    private Integer rating;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
+    // TODO : 삭제되어야 함
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_id")
     private Menu menu;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meal_id")
+    private Meal meal;
 
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewImage> reviewImages = new ArrayList<>();

--- a/src/main/java/ssu/eatssu/domain/review/entity/ReviewLike.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/ReviewLike.java
@@ -1,0 +1,38 @@
+package ssu.eatssu.domain.review.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ssu.eatssu.domain.user.entity.User;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ReviewLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public static ReviewLike create(User user, Review review) {
+        return new ReviewLike(null, review, user);
+    }
+}

--- a/src/main/java/ssu/eatssu/domain/review/entity/ReviewMenuLike.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/ReviewMenuLike.java
@@ -1,0 +1,43 @@
+package ssu.eatssu.domain.review.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ssu.eatssu.domain.menu.entity.Menu;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class ReviewMenuLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_menu_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id")
+    private Menu menu;
+
+    @Column(nullable = false)
+    private Boolean isLike; // true : 좋아요, false : 싫어요
+
+    public void updateLike(Boolean like) {
+        isLike = like;
+    }
+}

--- a/src/main/java/ssu/eatssu/domain/review/entity/ReviewMenuLike.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/ReviewMenuLike.java
@@ -48,4 +48,8 @@ public class ReviewMenuLike {
                 .isLike(isLike)
                 .build();
     }
+
+    public void resetMenuLikeStatus() {
+        menu.adjustLikeCount(-1, this.isLike);
+    }
 }

--- a/src/main/java/ssu/eatssu/domain/review/entity/ReviewMenuLike.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/ReviewMenuLike.java
@@ -40,4 +40,12 @@ public class ReviewMenuLike {
     public void updateLike(Boolean like) {
         isLike = like;
     }
+
+    public static ReviewMenuLike create(Review review, Menu menu, Boolean isLike) {
+        return ReviewMenuLike.builder()
+                .review(review)
+                .menu(menu)
+                .isLike(isLike)
+                .build();
+    }
 }

--- a/src/main/java/ssu/eatssu/domain/review/entity/ReviewMenuLike.java
+++ b/src/main/java/ssu/eatssu/domain/review/entity/ReviewMenuLike.java
@@ -50,6 +50,6 @@ public class ReviewMenuLike {
     }
 
     public void resetMenuLikeStatus() {
-        menu.adjustLikeCount(-1, this.isLike);
+        menu.cancelLike(this.isLike);
     }
 }

--- a/src/main/java/ssu/eatssu/domain/review/presentation/MealReviewController.java
+++ b/src/main/java/ssu/eatssu/domain/review/presentation/MealReviewController.java
@@ -129,4 +129,18 @@ public class MealReviewController {
         mealReviewService.deleteReview(customUserDetails, reviewId);
         return BaseResponse.success();
     }
+
+    @Operation(summary = "리뷰 좋아요 누르기/취소하기", description = "리뷰에 좋아요(찜)를 누르거나 취소하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 좋아요 토글 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 리뷰", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    @PostMapping("/{reviewId}/like")
+    public BaseResponse<?> toggleReviewLike(
+            @Parameter(description = "reviewId") @PathVariable("reviewId") Long reviewId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        mealReviewService.toggleReviewLike(customUserDetails, reviewId);
+        return BaseResponse.success();
+    }
 }

--- a/src/main/java/ssu/eatssu/domain/review/presentation/MealReviewController.java
+++ b/src/main/java/ssu/eatssu/domain/review/presentation/MealReviewController.java
@@ -1,6 +1,7 @@
 package ssu.eatssu.domain.review.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -8,12 +9,16 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import ssu.eatssu.domain.auth.security.CustomUserDetails;
+import ssu.eatssu.domain.restaurant.entity.Restaurant;
 import ssu.eatssu.domain.review.dto.CreateMealReviewRequest;
+import ssu.eatssu.domain.review.dto.RestaurantReviewResponse;
 import ssu.eatssu.domain.review.service.MealReviewService;
 import ssu.eatssu.global.handler.response.BaseResponse;
 
@@ -39,4 +44,20 @@ public class MealReviewController {
         return BaseResponse.success();
     }
 
+    @Operation(summary = "특정 식당 모든 리뷰 정보 조회(리뷰 개수, 평점 등등)", description = """
+            특정 식당 모든 리뷰 정보를 조회하는 API 입니다.<br><br>
+            리뷰 개수, 별점 별 개수, 리뷰 평점, 좋아요 개수, 싫어요 개수를 조회합니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 정보 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "path parameter 누락", content = @Content(schema =
+            @Schema(implementation = BaseResponse.class)))
+    })
+    @GetMapping("/statistics")
+    public BaseResponse<RestaurantReviewResponse> getRestaurantReviews(
+            @Parameter(description = "restaurant")
+            @RequestParam Restaurant restaurant
+    ) {
+        return BaseResponse.success(mealReviewService.findRestaurantReviews(restaurant));
+    }
 }

--- a/src/main/java/ssu/eatssu/domain/review/presentation/MealReviewController.java
+++ b/src/main/java/ssu/eatssu/domain/review/presentation/MealReviewController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -111,6 +112,21 @@ public class MealReviewController {
             @RequestBody UpdateMealReviewRequest request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         mealReviewService.updateReview(customUserDetails, reviewId, request);
+        return BaseResponse.success();
+    }
+
+    @Operation(summary = "리뷰 삭제", description = "리뷰를 삭제하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "리뷰에 대한 권한이 없음", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 리뷰", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    @DeleteMapping("/{reviewId}")
+    public BaseResponse<?> deleteReview(
+            @Parameter(description = "reviewId") @PathVariable("reviewId") Long reviewId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        mealReviewService.deleteReview(customUserDetails, reviewId);
         return BaseResponse.success();
     }
 }

--- a/src/main/java/ssu/eatssu/domain/review/presentation/MealReviewController.java
+++ b/src/main/java/ssu/eatssu/domain/review/presentation/MealReviewController.java
@@ -1,0 +1,42 @@
+package ssu.eatssu.domain.review.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ssu.eatssu.domain.auth.security.CustomUserDetails;
+import ssu.eatssu.domain.review.dto.CreateMealReviewRequest;
+import ssu.eatssu.domain.review.service.MealReviewService;
+import ssu.eatssu.global.handler.response.BaseResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/reviews")
+@Tag(name = "Review V2", description = "리뷰 V2 API")
+public class MealReviewController {
+    private final MealReviewService mealReviewService;
+
+    @Operation(summary = "리뷰 작성", description = "리뷰를 작성하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 작성 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 식단", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 메뉴", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+    })
+    @PostMapping()
+    public BaseResponse<?> createReview(
+            @RequestBody CreateMealReviewRequest createMealReviewRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        mealReviewService.createReview(customUserDetails, createMealReviewRequest);
+        return BaseResponse.success();
+    }
+
+}

--- a/src/main/java/ssu/eatssu/domain/review/presentation/MealReviewController.java
+++ b/src/main/java/ssu/eatssu/domain/review/presentation/MealReviewController.java
@@ -14,6 +14,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +26,7 @@ import ssu.eatssu.domain.restaurant.entity.Restaurant;
 import ssu.eatssu.domain.review.dto.CreateMealReviewRequest;
 import ssu.eatssu.domain.review.dto.MealReviewResponse;
 import ssu.eatssu.domain.review.dto.RestaurantReviewResponse;
+import ssu.eatssu.domain.review.dto.UpdateMealReviewRequest;
 import ssu.eatssu.domain.review.service.MealReviewService;
 import ssu.eatssu.domain.slice.dto.SliceResponse;
 import ssu.eatssu.global.handler.response.BaseResponse;
@@ -87,5 +90,27 @@ public class MealReviewController {
         SliceResponse<MealReviewResponse> myReviews = mealReviewService.findReviews(mealId, lastReviewId, pageable,
                 customUserDetails);
         return BaseResponse.success(myReviews);
+    }
+
+    @Operation(summary = "리뷰 수정(글 수정)", description = """
+            리뷰 내용을 수정하는 API 입니다.<br><br>
+            글 수정만 가능하며 사진 수정은 지원하지 않습니다.
+            """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "리뷰 수정 성공"),
+            @ApiResponse(responseCode = "403", description = "리뷰에 대한 권한이 없음", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 리뷰", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema =
+            @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 메뉴", content = @Content(schema =
+            @Schema(implementation = BaseResponse.class)))
+    })
+    @PatchMapping("/{reviewId}")
+    public BaseResponse<?> updateReview(@Parameter(description = "reviewId")
+    @PathVariable("reviewId") Long reviewId,
+            @RequestBody UpdateMealReviewRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        mealReviewService.updateReview(customUserDetails, reviewId, request);
+        return BaseResponse.success();
     }
 }

--- a/src/main/java/ssu/eatssu/domain/review/presentation/ReviewController.java
+++ b/src/main/java/ssu/eatssu/domain/review/presentation/ReviewController.java
@@ -119,7 +119,6 @@ public class ReviewController {
         return BaseResponse.success();
     }
 
-
     @Operation(summary = "리뷰 수정(글 수정)", description = """
             리뷰 내용을 수정하는 API 입니다.<br><br>
             글 수정만 가능하며 사진 수정은 지원하지 않습니다.

--- a/src/main/java/ssu/eatssu/domain/review/presentation/ReviewController.java
+++ b/src/main/java/ssu/eatssu/domain/review/presentation/ReviewController.java
@@ -1,5 +1,6 @@
 package ssu.eatssu.domain.review.presentation;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -64,6 +65,7 @@ public class ReviewController {
         return BaseResponse.success(myReviews);
     }
 
+    @Hidden
     @Operation(summary = "리뷰 작성", description = """
             리뷰를 작성하는 API 입니다.<br><br>
             reviewCreate는 application/json, multipartFileList는 multipart/form-data로 요청해주세요.<br><br>

--- a/src/main/java/ssu/eatssu/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/ssu/eatssu/domain/review/repository/ReviewLikeRepository.java
@@ -1,0 +1,11 @@
+package ssu.eatssu.domain.review.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import ssu.eatssu.domain.review.entity.Review;
+import ssu.eatssu.domain.review.entity.ReviewLike;
+import ssu.eatssu.domain.user.entity.User;
+
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
+    Optional<ReviewLike> findByReviewAndUser(Review review, User user);
+}

--- a/src/main/java/ssu/eatssu/domain/review/repository/ReviewMenuLikeRepository.java
+++ b/src/main/java/ssu/eatssu/domain/review/repository/ReviewMenuLikeRepository.java
@@ -1,0 +1,10 @@
+package ssu.eatssu.domain.review.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import ssu.eatssu.domain.review.entity.Review;
+import ssu.eatssu.domain.review.entity.ReviewMenuLike;
+
+public interface ReviewMenuLikeRepository extends JpaRepository<ReviewMenuLike, Long> {
+    List<ReviewMenuLike> findByReview(Review review);
+}

--- a/src/main/java/ssu/eatssu/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/ssu/eatssu/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,10 @@
 package ssu.eatssu.domain.review.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import ssu.eatssu.domain.menu.entity.Meal;
 import ssu.eatssu.domain.menu.entity.Menu;
 import ssu.eatssu.domain.review.entity.Review;
@@ -20,4 +24,9 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
     Long countByMenu_MealMenus_Meal(Meal meal);
 
     List<Review> findByMealIn(List<Meal> meals);
+
+    @Query("SELECT r FROM Review r WHERE r.meal.id IN :mealIds AND (:lastReviewId IS NULL OR r.id < :lastReviewId) ")
+    Page<Review> findReviewsByMealIds(@Param("mealIds") List<Long> mealIds,
+            @Param("lastReviewId") Long lastReviewId,
+            Pageable pageable);
 }

--- a/src/main/java/ssu/eatssu/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/ssu/eatssu/domain/review/repository/ReviewRepository.java
@@ -19,4 +19,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
 
     Long countByMenu_MealMenus_Meal(Meal meal);
 
+    List<Review> findByMealIn(List<Meal> meals);
 }

--- a/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
+++ b/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
@@ -188,19 +188,7 @@ public class MealReviewService {
             throw new BaseException(REVIEW_PERMISSION_DENIED);
         }
 
-        List<ReviewMenuLike> reviewMenuLikes = reviewMenuLikeRepository.findByReview(review);
-
-        // ReviewMenuLike 삭제 전, 메뉴의 likeCount와 unlikeCount 수정
-        for (ReviewMenuLike reviewMenuLike : reviewMenuLikes) {
-            Menu menu = reviewMenuLike.getMenu();
-            if (reviewMenuLike.getIsLike()) {
-                menu.decreaseLikeCount();
-            } else {
-                menu.decreaseUnlikeCount();
-            }
-        }
-
-        reviewMenuLikeRepository.deleteAll(reviewMenuLikes);
+        review.resetMenuLikes();
         reviewRepository.delete(review);
     }
 

--- a/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
+++ b/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
@@ -1,0 +1,76 @@
+package ssu.eatssu.domain.review.service;
+
+import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_MEAL;
+import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_MENU;
+import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_USER;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ssu.eatssu.domain.auth.security.CustomUserDetails;
+import ssu.eatssu.domain.menu.entity.Meal;
+import ssu.eatssu.domain.menu.entity.Menu;
+import ssu.eatssu.domain.menu.persistence.MealMenuRepository;
+import ssu.eatssu.domain.menu.persistence.MealRepository;
+import ssu.eatssu.domain.menu.persistence.MenuRepository;
+import ssu.eatssu.domain.review.dto.CreateMealReviewRequest;
+import ssu.eatssu.domain.review.dto.MenuLikeRequest;
+import ssu.eatssu.domain.review.entity.Review;
+import ssu.eatssu.domain.review.entity.ReviewImage;
+import ssu.eatssu.domain.review.entity.ReviewMenuLike;
+import ssu.eatssu.domain.review.repository.ReviewImageRepository;
+import ssu.eatssu.domain.review.repository.ReviewMenuLikeRepository;
+import ssu.eatssu.domain.review.repository.ReviewRepository;
+import ssu.eatssu.domain.user.entity.User;
+import ssu.eatssu.domain.user.repository.UserRepository;
+import ssu.eatssu.global.handler.response.BaseException;
+
+@RequiredArgsConstructor
+@Service
+public class MealReviewService {
+    private final UserRepository userRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewImageRepository reviewImageRepository;
+    private final MenuRepository menuRepository;
+    private final MealRepository mealRepository;
+    private final ReviewMenuLikeRepository reviewMenuLikeRepository;
+
+    /**
+     * 리뷰 생성
+     */
+    @Transactional
+    public void createReview(CustomUserDetails userDetails, CreateMealReviewRequest request) {
+        User user = userRepository.findById(userDetails.getId())
+                .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+
+        Meal meal = mealRepository.findById(request.getMealId())
+                .orElseThrow(() -> new BaseException(NOT_FOUND_MEAL));
+
+        Review review = request.toReviewEntity(user, meal);
+        reviewRepository.save(review);
+
+        List<ReviewImage> reviewImages = request.createReviewImages(review);
+        reviewImageRepository.saveAll(reviewImages);
+
+        for (MenuLikeRequest menuLikes : request.getMenuLikes()) {
+            Menu menu = menuRepository.findById(menuLikes.getMenuId())
+                    .orElseThrow(() -> new BaseException(NOT_FOUND_MENU));
+
+            // 리뷰-메뉴 좋아요 정보 저장
+            ReviewMenuLike reviewMenuLike = ReviewMenuLike.builder()
+                    .review(review)
+                    .menu(menu)
+                    .isLike(menuLikes.getIsLike()).build();
+            reviewMenuLikeRepository.save(reviewMenuLike);
+
+            // 메뉴에 좋아요/싫어요 수 반영
+            if (menuLikes.getIsLike()) {
+                menu.increaseLikeCount();
+            }
+            else {
+                menu.increaseUnlikeCount();
+            }
+        }
+    }
+}

--- a/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
+++ b/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
@@ -8,6 +8,7 @@ import static ssu.eatssu.global.handler.response.BaseResponseStatus.REVIEW_PERMI
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -29,8 +30,8 @@ import ssu.eatssu.domain.review.dto.RestaurantReviewResponse;
 import ssu.eatssu.domain.review.dto.ReviewRatingCount;
 import ssu.eatssu.domain.review.dto.UpdateMealReviewRequest;
 import ssu.eatssu.domain.review.entity.Review;
-import ssu.eatssu.domain.review.repository.ReviewImageRepository;
-import ssu.eatssu.domain.review.repository.ReviewMenuLikeRepository;
+import ssu.eatssu.domain.review.entity.ReviewLike;
+import ssu.eatssu.domain.review.repository.ReviewLikeRepository;
 import ssu.eatssu.domain.review.repository.ReviewRepository;
 import ssu.eatssu.domain.slice.dto.SliceResponse;
 import ssu.eatssu.domain.user.dto.MyMealReviewResponse;
@@ -46,6 +47,7 @@ public class MealReviewService {
     private final MenuRepository menuRepository;
     private final MealRepository mealRepository;
     private final MealMenuRepository mealMenuRepository;
+    private final ReviewLikeRepository reviewLikeRepository;
 
     /**
      * 리뷰 생성
@@ -198,5 +200,29 @@ public class MealReviewService {
                 .hasNext(sliceReviews.hasNext())
                 .dataList(myMealReviewResponses)
                 .build();
+    }
+
+    /**
+     * 리뷰 좋아요 누르기/취소하기
+     */
+    @Transactional
+    public void toggleReviewLike(CustomUserDetails userDetails, Long reviewId) {
+        User user = userRepository.findById(userDetails.getId())
+                .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_REVIEW));
+
+        Optional<ReviewLike> optionalReviewLike = reviewLikeRepository.findByReviewAndUser(review, user);
+        if (optionalReviewLike.isPresent()) {
+            // 이미 좋아요 한 경우 -> 좋아요 취소 처리
+            ReviewLike reviewLike = optionalReviewLike.get();
+            review.getReviewLikes().remove(reviewLike);
+            reviewLikeRepository.delete(reviewLike);
+        } else {
+            // 좋아요 하지 않은 경우 -> 좋아요 추가 처리
+            ReviewLike reviewLike = ReviewLike.create(user, review);
+            review.getReviewLikes().add(reviewLike);
+            reviewLikeRepository.save(reviewLike);
+        }
     }
 }

--- a/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
+++ b/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
@@ -113,14 +113,12 @@ public class MealReviewService {
         }
 
         List<Long> menuIds = mealMenuRepository.findMenuIdsByMealId(mealId);
-
         if (menuIds.isEmpty()) {
             return SliceResponse.empty();
         }
 
         List<Long> mealIds = mealMenuRepository.findMealIdsByMenuIds(menuIds);
-
-        if (menuIds.isEmpty()) {
+        if (mealIds.isEmpty()) {
             return SliceResponse.empty();
         }
 

--- a/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
+++ b/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
@@ -97,7 +97,7 @@ public class MealReviewService {
         return RestaurantReviewResponse.builder()
                 .totalReviewCount(reviews.size())
                 .reviewRatingCount(reviewRatingCount)
-                .mainRating(averageRating)
+                .mainRating(Math.round(averageRating * 10) / 10.0)
                 .likeCount(likeCount)
                 .unlikeCount(unlikeCount)
                 .build();

--- a/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
+++ b/src/main/java/ssu/eatssu/domain/review/service/MealReviewService.java
@@ -124,9 +124,10 @@ public class MealReviewService {
 
         Page<Review> pageReviews = reviewRepository.findReviewsByMealIds(mealIds, lastReviewId, pageable);
 
+        Long userId = (userDetails != null) ? userDetails.getId() : null;
         List<MealReviewResponse> mealReviewResponses =
                 pageReviews.getContent().stream().map(review -> MealReviewResponse.from(review,
-                        userDetails.getId())).collect(Collectors.toList());
+                        userId)).collect(Collectors.toList());
 
         return SliceResponse.<MealReviewResponse>builder()
                 .numberOfElements(pageReviews.getNumberOfElements())

--- a/src/main/java/ssu/eatssu/domain/slice/dto/SliceResponse.java
+++ b/src/main/java/ssu/eatssu/domain/slice/dto/SliceResponse.java
@@ -1,6 +1,7 @@
 package ssu.eatssu.domain.slice.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Collections;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,4 +20,8 @@ public class SliceResponse<D> {
 
     @Schema(description = "데이터 리스트")
     private List<D> dataList;
+
+    public static <T> SliceResponse<T> empty() {
+        return new SliceResponse<>(0, false, Collections.emptyList());
+    }
 }

--- a/src/main/java/ssu/eatssu/domain/user/dto/MyMealReviewResponse.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/MyMealReviewResponse.java
@@ -1,0 +1,44 @@
+package ssu.eatssu.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import ssu.eatssu.domain.review.entity.Review;
+
+@AllArgsConstructor
+@Builder
+@Schema(title = "리뷰 상세 - 내 리뷰 리스트 조회 용")
+@Getter
+public class MyMealReviewResponse {
+    @Schema(description = "리뷰 식별자", example = "123")
+    Long reviewId;
+
+    @Schema(description = "평점", example = "4")
+    private Integer rating;
+
+    @Schema(description = "리뷰 작성 날짜(format = yyyy-MM-dd)", example = "2023-04-07")
+    private LocalDate writtenAt;
+
+    @Schema(description = "리뷰 내용", example = "맛있습니당")
+    private String content;
+
+    @Schema(description = "리뷰 이미지 url 리스트", example = "[\"imgurl1\", \"imgurl2\"]")
+    private List<String> imageUrls;
+
+    public static MyMealReviewResponse from(Review review) {
+        List<String> imgUrlList = new ArrayList<>();
+        review.getReviewImages().forEach(i->imgUrlList.add(i.getImageUrl()));
+
+        return MyMealReviewResponse.builder()
+                .reviewId(review.getId())
+                .rating(review.getRating())
+                .writtenAt(review.getCreatedDate().toLocalDate())
+                .content(review.getContent())
+                .imageUrls(imgUrlList)
+                .build();
+    }
+}

--- a/src/main/java/ssu/eatssu/domain/user/entity/User.java
+++ b/src/main/java/ssu/eatssu/domain/user/entity/User.java
@@ -8,11 +8,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import ssu.eatssu.domain.auth.entity.OAuthProvider;
+import ssu.eatssu.domain.department.entity.Department;
 import ssu.eatssu.domain.inquiry.entity.Inquiry;
 import ssu.eatssu.domain.review.entity.Review;
 import ssu.eatssu.domain.review.entity.Report;
 
 import java.util.List;
+import ssu.eatssu.domain.review.entity.ReviewLike;
 
 @Entity
 @Getter
@@ -51,6 +53,13 @@ public class User extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "user", cascade = {CascadeType.ALL})
     private List<Inquiry> userInquiries = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id")
+    private Department department;
+
+    @OneToMany(mappedBy = "user", cascade = {CascadeType.ALL}, orphanRemoval = true)
+    private List<ReviewLike> reviewLikes = new ArrayList<>();
 
     /**
      * Oauth 회원가입 용 생성자

--- a/src/main/java/ssu/eatssu/domain/user/entity/User.java
+++ b/src/main/java/ssu/eatssu/domain/user/entity/User.java
@@ -55,9 +55,10 @@ public class User extends BaseTimeEntity {
     /**
      * Oauth 회원가입 용 생성자
      */
-    private User(@NotNull String email, @NotNull Role role, @NotNull OAuthProvider provider,
+    private User(@NotNull String email, String nickname, @NotNull Role role, @NotNull OAuthProvider provider,
                  @NotNull String providerId, @NotNull UserStatus status, @NotNull String credentials) {
         this.email = email;
+        this.nickname = nickname;
         this.role = role;
         this.provider = provider;
         this.providerId = providerId;
@@ -69,9 +70,10 @@ public class User extends BaseTimeEntity {
      * <--Static Factory Method-->
      * Oauth 회원가입
      */
-    public static User create(@NotNull String email, @NotNull OAuthProvider provider, String providerId,
+    public static User create(@NotNull String email, @NotNull String nickname, @NotNull OAuthProvider provider,
+            String providerId,
                                  String credentials) {
-        return new User(email, Role.USER, provider, providerId, UserStatus.ACTIVE, credentials);
+        return new User(email, nickname, Role.USER, provider, providerId, UserStatus.ACTIVE, credentials);
     }
 
     /**
@@ -80,7 +82,7 @@ public class User extends BaseTimeEntity {
      * Role 은 다른 방법으로 세팅할 예정
      */
     public static User adminJoin(@NotNull String loginId, @NotNull String credentials) {
-        return new User(loginId, Role.USER, OAuthProvider.EATSSU, loginId, UserStatus.INACTIVE, credentials);
+        return new User(loginId, null, Role.USER, OAuthProvider.EATSSU, loginId, UserStatus.INACTIVE, credentials);
     }
 
     public void updateNickname(@NotNull String nickname) {

--- a/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
+++ b/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
@@ -17,6 +17,8 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import ssu.eatssu.domain.auth.security.CustomUserDetails;
+import ssu.eatssu.domain.review.service.MealReviewService;
+import ssu.eatssu.domain.user.dto.MyMealReviewResponse;
 import ssu.eatssu.domain.user.dto.MyReviewDetail;
 import ssu.eatssu.domain.user.dto.MyPageResponse;
 import ssu.eatssu.domain.slice.dto.SliceResponse;
@@ -33,6 +35,7 @@ public class UserController {
 
     private final UserService userService;
     private final SliceService sliceService;
+    private final MealReviewService mealReviewService;
 
     @Operation(summary = "이메일 중복 체크", description = """
         이메일 중복 체크 API 입니다.<br><br>
@@ -96,6 +99,22 @@ public class UserController {
         SliceResponse<MyReviewDetail> myReviews = sliceService.findMyReviews(customUserDetails,
             pageable,
             lastReviewId);
+        return BaseResponse.success(myReviews);
+    }
+
+    @Operation(summary = "내가 쓴 리뷰 리스트 조회 V2", description = "내가 쓴 리뷰 리스트를 조회하는 API V2 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내가 쓴 리뷰 리스트 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    @GetMapping("/v2/reviews")
+    public BaseResponse<SliceResponse<MyMealReviewResponse>> getMyReviews(
+            @Parameter(description = "마지막으로 조회된 reviewId값(첫 조회시 값 필요 없음)", in = ParameterIn.QUERY) @RequestParam(required = false) Long lastReviewId,
+            @ParameterObject @PageableDefault(size = 20, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        SliceResponse<MyMealReviewResponse> myReviews = mealReviewService.findMyReviews(customUserDetails,
+                lastReviewId,
+                pageable);
         return BaseResponse.success(myReviews);
     }
 

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package ssu.eatssu.domain.user.service;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_USER;
 
 import jakarta.transaction.Transactional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,7 +30,8 @@ public class UserService {
 
     public User join(String email, OAuthProvider provider, String providerId) {
         String credentials = createCredentials(provider, providerId);
-        User user = User.create(email, provider, providerId, credentials);
+        String nickname = createNickname();
+        User user = User.create(email, nickname, provider, providerId, credentials);
         return userRepository.save(user);
     }
 
@@ -63,6 +65,12 @@ public class UserService {
 
     public Boolean validateDuplicatedNickname(String nickname) {
         return !userRepository.existsByNickname(nickname);
+    }
+
+    public String createNickname() {
+        String uuid = UUID.randomUUID().toString();
+        String shortUUID = uuid.substring(0, 4);
+        return "user-" + shortUUID;
     }
 
     private String createCredentials(OAuthProvider provider, String providerId) {

--- a/src/main/java/ssu/eatssu/domain/user/util/UserAliasUtil.java
+++ b/src/main/java/ssu/eatssu/domain/user/util/UserAliasUtil.java
@@ -1,0 +1,32 @@
+package ssu.eatssu.domain.user.util;
+
+import java.util.List;
+import ssu.eatssu.domain.review.entity.Review;
+import ssu.eatssu.domain.user.entity.User;
+
+public class UserAliasUtil {
+    public static String getUserAlias(User user, List<Review> reviews) {
+        if (reviews == null || reviews.isEmpty()) {
+            return "미슈테리 미식가";
+        }
+        double avg = reviews.stream()
+                .mapToInt(Review::getRating)
+                .average()
+                .orElse(0.0);
+        int avgRating = (int) Math.round(avg);
+        switch (avgRating) {
+            case 1:
+                return "깐깐슈";
+            case 2:
+                return "아이슈";
+            case 3:
+                return "밸런슈";
+            case 4:
+                return "딱좋슈";
+            case 5:
+                return "다 맛있슈";
+            default:
+                return "미슈테리 미식가";
+        }
+    }
+}

--- a/src/test/java/ssu/eatssu/domain/report/service/ReportServiceTest.java
+++ b/src/test/java/ssu/eatssu/domain/report/service/ReportServiceTest.java
@@ -60,7 +60,7 @@ class ReportServiceTest {
     }
 
     private User createUser() {
-        return User.create("test1@test.com", OAuthProvider.EATSSU, "1234", "1234");
+        return User.create("test1@test.com", "user-test", OAuthProvider.EATSSU, "1234", "1234");
     }
 
     private CustomUserDetails createCustomUserDetails(User user) {

--- a/src/test/java/ssu/eatssu/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/ssu/eatssu/domain/review/service/ReviewServiceTest.java
@@ -95,7 +95,7 @@ class ReviewServiceTest {
     }
 
     private User createUser() {
-        return User.create("test@test.com", OAuthProvider.EATSSU, "1234", "1234");
+        return User.create("test@test.com", "user-test", OAuthProvider.EATSSU, "1234", "1234");
     }
 
     private CustomUserDetails createCustomUserDetails(User user) {


### PR DESCRIPTION
## 작업 내용
- 이번 리뷰 v2의 주요 변화는 기존 리뷰가 menu와의 연관관계에서 meal로 변경된 점입니다.
- 이에 따라, 리뷰 테이블에 meal과의 연관관계를 추가하였습니다.
- menu 테이블에 likeCount, unlikeCount 컬럼이 추가되었습니다.
  - 리뷰를 통해 얻은 menu의 like, unlike 정보를 review_menu_like 테이블에서 관리합니다. (`review<->review_menu_like<->menu 1:N:1 관계입니다.`)
- 리뷰 v2 api를 구현하였습니다.
  - 리뷰 작성
  - 리뷰 수정
  - 리뷰 삭제
  - 특정 식당 모든 리뷰 조회(기존 리뷰 정보 조회 api의 역할)
  - 리뷰 리스트 조회(기존 리뷰 리스트 조회 api의 역할)
  - 내가 쓴 리뷰 리스트 조회
- resolved: #107 > 해당 이슈 해결하였습니다.([045011c](https://github.com/EAT-SSU/Server/pull/109/commits/045011c881147a719efbae139bdfcac9294ec5c5))  로그인 시, 기본 닉네임을 `user-uuid(4글자로 조정)`로 설정하였습니다.
 
## 리뷰 요청사항
- MealReviewService & Review 클래스 내 메서드의 길이가 어마무시한데 어떻게 리팩토링하면 좋을까요...?.. 좋은 아이디어가 있으면 마구 던져주세요:)