### PR TITLE
Refactor unused Model package and specify return type of BaseResponse in ManageCategoryController

### DIFF
--- a/src/main/java/ssu/eatssu/domain/admin/controller/ManageCategoryController.java
+++ b/src/main/java/ssu/eatssu/domain/admin/controller/ManageCategoryController.java
@@ -17,7 +17,7 @@ public class ManageCategoryController {
 
     @ResponseBody
     @PostMapping("/")
-    public BaseResponse register(@RequestParam Restaurant restaurant,
+    public BaseResponse<Void> register(@RequestParam Restaurant restaurant,
                                          @RequestBody RegisterCategoryRequest request) {
         manageCategoryService.register(restaurant, request);
         return BaseResponse.success();

--- a/src/main/java/ssu/eatssu/domain/admin/controller/ManageFixMenuController.java
+++ b/src/main/java/ssu/eatssu/domain/admin/controller/ManageFixMenuController.java
@@ -2,7 +2,6 @@ package ssu.eatssu.domain.admin.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import ssu.eatssu.domain.admin.dto.MenuBoards;
 import ssu.eatssu.domain.admin.dto.RegisterFixMenuRequest;


### PR DESCRIPTION
# 수정 제안

## 설명
1. **제네릭의 기본 원리**
- `BaseResponse<T>`는 제네릭 클래스로, T는 타입 파라미터입니다.
- 이는 클래스가 다양한 타입을 처리할 수 있도록 해주는 유연성을 제공합니다.
- 코드에서 `T result`처럼 실제 데이터를 담는 필드가 있어, 어떤 타입의 결과값도 반환할 수 있습니다.

2. **Raw Type 사용 시 문제점**
- Raw Type이란 `BaseResponse`처럼 타입 파라미터 없이 사용하는 것을 말합니다.
- Raw Type을 사용하면:
  - 컴파일러가 타입 안정성을 보장할 수 없습니다
  - 런타임에 예기치 않은 ClassCastException이 발생할 수 있습니다
  - 제네릭의 장점인 컴파일 시점 타입 체크가 불가능합니다

3. **현재 코드의 경우**
```java
public static <T> BaseResponse<T> success() {
    return new BaseResponse<>(BaseResponseStatus.SUCCESS);
}
```
- `success()` 메소드는 데이터 없이 성공 상태만 반환합니다
- 이 경우 반환값이 없으므로 `Void` 타입을 명시하여 `BaseResponse<Void>`로 사용하는 것이 타입 안정성을 보장하는 올바른 방법입니다

따라서 컨트롤러에서:
```java
public BaseResponse<Void> register(...)
```
이렇게 명시적으로 타입을 지정하는 것이 자바의 타입 시스템을 올바르게 사용하는 방법입니다.

## 생각

- 위의 설명에 의거하여 다음과 같은 리팩터링을 제안합니다.
- 별로다 싶으면 언제든 편하게 거부해주시면 됩니다!
- 승인하시면 해당 경고가 확인되는 모든 클래스에 일괄적으로 적용해서 PR을 발송하겠습니다.