### PR TITLE
feat: 컴파일러에 Java 17로 빌드 명시

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ out/
 
 ### Docker Tar files ###
 /eat-ssu.tar
+
+### SDKMAN ###
+.sdkmanrc

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,2 @@
+# 프로젝트 루트/.sdkmanrc
+java=17.0.14-jbr

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,2 +1,0 @@
-# 프로젝트 루트/.sdkmanrc
-java=17.0.14-jbr

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,12 @@ bootJar {
     archiveVersion = "0.0.1"
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor


### PR DESCRIPTION
# 설명

- 로컬에서 sdkman으로 여러 자바 버전을 사용하고 있는데, 우리 프로젝트에서는 Java 17을 사용하고 있기 때문에 컴파일러에서 Java 17로 빌드할 수 있도록 명시했습니다.

- `.sdkmanrc` 파일을 사용해서 sdkman을 사용하는 개발환경에서는 기본 Java를 17로 사용하게 지정했습니다.