### PR TITLE
refactor: access token 없이 토큰 인증할수 있게 수정

### DIFF
--- a/src/main/java/ssu/eatssu/domain/auth/infrastructure/SecurityConfig.java
+++ b/src/main/java/ssu/eatssu/domain/auth/infrastructure/SecurityConfig.java
@@ -23,7 +23,7 @@ import ssu.eatssu.global.handler.JwtAuthenticationEntryPoint;
 @RequiredArgsConstructor
 public class SecurityConfig {
 	private static final String[] RESOURCE_LIST = {
-		"/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/admin/img/**", "/css/**", "/js/**",
+		"/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**","/oauths/valid/token", "/admin/img/**", "/css/**", "/js/**",
 		"/favicon.ico", "/error/**", "/webjars/**", "/h2-console/**"
 	};
 

--- a/src/main/java/ssu/eatssu/domain/auth/presentation/OAuthController.java
+++ b/src/main/java/ssu/eatssu/domain/auth/presentation/OAuthController.java
@@ -74,7 +74,7 @@ public class OAuthController {
 		return BaseResponse.success(tokens);
 	}
 
-	@Operation(summary = "유효한 토큰 확인", description = "해당 토큰이 유효하면 true 반환하는, 유효하지 않은 false 반환하는 API 입니다")
+	@Operation(summary = "유효한 토큰 확인 [인증 토큰 필요 X]", description = "해당 토큰이 유효하면 true 반환하는, 유효하지 않은 false 반환하는 API 입니다")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "유효한 토큰인지 확인 성공")
 	})


### PR DESCRIPTION
## #️⃣ Issue Number

 - #141 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

1. 토큰이 없는 경우 -> NoValidToken -> LoginAcitivity
2. 토큰이 있지만 유효하지 않은 경우 -> NoValidToken -> LoginActivity
3. 토큰이 있고 유효한 경우 -> Success -> MainActivity
-> 해당 프론트에 요청에 맞게 토큰이 없을때 인증할수 있게 수정

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
