### PR TITLE
hotfix: 운영서버 도커 배포가 안되는 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: EAT-SSU Server 개발 & 운영 서버 배포 파이프라인
 
 on:
   push:
-    branches: [ "main", "develop" ]
+    branches: [ "main", "develop", "hotfix/deploy-prod-fail" ]
 
 permissions:
   contents: read
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: dev 프로필 설정
-        if: contains(github.ref, 'dev')
+        if: github.ref_name == 'develop'
         run: |
           echo "spring:
             profiles:
@@ -38,7 +38,7 @@ jobs:
         shell: bash
 
       - name: prod 프로필 설정
-        if: contains(github.ref, 'main')
+        if: github.ref_name == 'main' || github.ref_name == 'hotfix/deploy-prod-fail'
         run: |
           echo "spring:
             profiles:
@@ -58,13 +58,13 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: prod 용 Docker 빌드 및 푸시
-        if: contains(github.ref, 'main')
+        if: github.ref_name == 'main' || github.ref_name == 'hotfix/deploy-prod-fail'
         run: |
           docker build -f Dockerfile -t ${{ secrets.DOCKER_REPO }}/eatssu-prod .
           docker push ${{ secrets.DOCKER_REPO }}/eatssu-prod
 
       - name: dev 서버 용 Docker 빌드 및 푸시
-        if: contains(github.ref, 'dev')
+        if: github.ref_name == 'develop'
         run: |
           docker build -f Dockerfile -t ${{ secrets.DOCKER_REPO }}/eatssu-dev .
           docker push ${{ secrets.DOCKER_REPO }}/eatssu-dev
@@ -72,12 +72,12 @@ jobs:
       - name: prod에 배포
         uses: appleboy/ssh-action@master
         id: deploy-prod
-        if: contains(github.ref, 'main')
+        if: github.ref_name == 'main' || github.ref_name == 'hotfix/deploy-prod-fail'
         with:
           host: ${{ secrets.HOST_PROD }}
-          username: ubuntu
+          username: ${{ secrets.USERNAME }}
           key: ${{ secrets.PROD_PRIVATE_KEY }}
-          envs: GITHUB_SHA
+          port: 22
           script: |
             sudo docker ps
             sudo docker rm -f $(docker ps -qa)
@@ -96,7 +96,7 @@ jobs:
       - name: dev 서버에 배포
         uses: appleboy/ssh-action@master
         id: deploy-dev
-        if: contains(github.ref, 'dev')
+        if: github.ref_name == 'develop'
         with:
           host: ${{ secrets.HOST_DEV }}
           username: ${{ secrets.USERNAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: EAT-SSU Server 개발 & 운영 서버 배포 파이프라인
 
 on:
   push:
-    branches: [ "main", "develop", "hotfix/deploy-prod-fail" ]
+    branches: [ "main", "develop", "hotfix/deploy-prod-fail", "hotfix/deploy-dev-fail" ]
 
 permissions:
   contents: read
@@ -30,7 +30,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: dev 프로필 설정
-        if: github.ref_name == 'develop'
+        if: github.ref_name == 'develop' || github.ref_name == 'hotfix/deploy-dev-fail'
         run: |
           echo "spring:
             profiles:
@@ -64,7 +64,7 @@ jobs:
           docker push ${{ secrets.DOCKER_REPO }}/eatssu-prod
 
       - name: dev 서버 용 Docker 빌드 및 푸시
-        if: github.ref_name == 'develop'
+        if: github.ref_name == 'develop' || github.ref_name == 'hotfix/deploy-dev-fail'
         run: |
           docker build -f Dockerfile -t ${{ secrets.DOCKER_REPO }}/eatssu-dev .
           docker push ${{ secrets.DOCKER_REPO }}/eatssu-dev
@@ -96,7 +96,7 @@ jobs:
       - name: dev 서버에 배포
         uses: appleboy/ssh-action@master
         id: deploy-dev
-        if: github.ref_name == 'develop'
+        if: github.ref_name == 'develop' || github.ref_name == 'hotfix/deploy-dev-fail'
         with:
           host: ${{ secrets.HOST_DEV }}
           username: ${{ secrets.USERNAME }}


### PR DESCRIPTION
- 배포 파이프라인에 'hotfix/deploy-prod-fail' 브랜치 추가
- dev 및 prod 프로필 설정 조건을 github.ref_name으로 변경하여 가독성 향상

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 운영서버 CD 파이프라인을 테스트 하기 위해서 `hotfix/deploy-prod-fail` 브랜치를 신규 생성해서 CD 파이프라인을 디버깅 하기 위한 목적으로 사용합니다.
- 마찬가지로 `hotfix/deploy-dev-fail` 브랜치를 사용하여 개발서버 CD 파이프라인을 디버깅 할 수 있도록 해두었습니다. 
- `main` 브랜치에 바로 해도 되긴하지만, 그래도 핫픽스 로그를 남기고 싶긴해서 이 방법을 한 번 해봤습니다. 의견 남겨주시면 감사할 것 같아요!!!

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- 해당 브랜치로 CD 파이프라인이 동작하게 설계되어있어서, 운영서버와 개발서버 모두 정상적으로 동작하고 있습니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
