### PR TITLE
feat: 마이페이지 API 개발

### DIFF
--- a/src/main/java/ssu/eatssu/domain/user/department/persistence/DepartmentRepository.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/persistence/DepartmentRepository.java
@@ -1,10 +1,14 @@
 package ssu.eatssu.domain.user.department.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import ssu.eatssu.domain.user.department.entity.College;
 import ssu.eatssu.domain.user.department.entity.Department;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
     Optional<Department> findByName(String name);
+
+    List<Department> findByCollege(College college);
 }

--- a/src/main/java/ssu/eatssu/domain/user/dto/GetCollegeResponse.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/GetCollegeResponse.java
@@ -1,0 +1,10 @@
+package ssu.eatssu.domain.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GetCollegeResponse(
+        Long id,
+        String name
+) {
+}

--- a/src/main/java/ssu/eatssu/domain/user/dto/GetDepartmentResponse.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/GetDepartmentResponse.java
@@ -1,0 +1,8 @@
+package ssu.eatssu.domain.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record GetDepartmentResponse(Long id,
+                                   String name) {
+}

--- a/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
+++ b/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
@@ -31,6 +31,8 @@ import ssu.eatssu.domain.review.service.ReviewServiceV2;
 import ssu.eatssu.domain.slice.dto.SliceResponse;
 import ssu.eatssu.domain.slice.service.SliceService;
 import ssu.eatssu.domain.user.dto.DepartmentResponse;
+import ssu.eatssu.domain.user.dto.GetCollegeResponse;
+import ssu.eatssu.domain.user.dto.GetDepartmentResponse;
 import ssu.eatssu.domain.user.dto.MyMealReviewResponse;
 import ssu.eatssu.domain.user.dto.MyPageResponse;
 import ssu.eatssu.domain.user.dto.MyReviewDetail;
@@ -199,4 +201,27 @@ public class UserController {
                                                                                       pageable);
         return BaseResponse.success(myReviews);
     }
+
+    @Operation(summary = "단과대 조회", description = "숭실대학교 단과대학 들을 조회하는 API입니다.(토큰 불필요)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "단과대 리스트 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    @GetMapping("/lookup/colleges")
+    public BaseResponse<List<GetCollegeResponse>> getColleges() {
+        List<GetCollegeResponse> getCollegeResponses = userService.getCollegeList();
+        return BaseResponse.success(getCollegeResponses);
+    }
+
+    @Operation(summary = "단과대에 따른 학과 조회", description = "단과대학을 입력하면 단과대에 속한 숭실대학교 학과를 조회하는 API입니다.(토큰 불필요)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "단과대 리스트 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    @GetMapping("/lookup/departments")
+    public BaseResponse<List<GetDepartmentResponse>> getDepartments(@RequestParam Long collegeId) {
+        List<GetDepartmentResponse> getCollegeResponses = userService.getDepartmentList(collegeId);
+        return BaseResponse.success(getCollegeResponses);
+    }
+
 }

--- a/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
+++ b/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
@@ -27,9 +27,11 @@ import org.springframework.web.bind.annotation.RestController;
 import ssu.eatssu.domain.auth.security.CustomUserDetails;
 import ssu.eatssu.domain.partnership.dto.PartnershipResponse;
 import ssu.eatssu.domain.partnership.service.PartnershipService;
+import ssu.eatssu.domain.review.service.ReviewServiceV2;
 import ssu.eatssu.domain.slice.dto.SliceResponse;
 import ssu.eatssu.domain.slice.service.SliceService;
 import ssu.eatssu.domain.user.dto.DepartmentResponse;
+import ssu.eatssu.domain.user.dto.MyMealReviewResponse;
 import ssu.eatssu.domain.user.dto.MyPageResponse;
 import ssu.eatssu.domain.user.dto.MyReviewDetail;
 import ssu.eatssu.domain.user.dto.NicknameUpdateRequest;
@@ -48,6 +50,7 @@ public class UserController {
     private final UserService userService;
     private final SliceService sliceService;
     private final PartnershipService partnershipService;
+    private final ReviewServiceV2 reviewServiceV2;
 
     @Operation(summary = "이메일 중복 체크", description = """
             이메일 중복 체크 API 입니다.<br><br>
@@ -179,5 +182,21 @@ public class UserController {
     @GetMapping("/department")
     public BaseResponse<DepartmentResponse> getDepartment(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return BaseResponse.success(userService.getDepartment(userDetails));
+    }
+
+    @Operation(summary = "내가 쓴 리뷰 리스트 조회", description = "내가 쓴 리뷰 리스트를 조회하는 API V2 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내가 쓴 리뷰 리스트 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    @GetMapping("/v2/reviews")
+    public BaseResponse<SliceResponse<MyMealReviewResponse>> getMyReviews(
+            @Parameter(description = "마지막으로 조회된 reviewId값(첫 조회시 값 필요 없음)", in = ParameterIn.QUERY) @RequestParam(required = false) Long lastReviewId,
+            @ParameterObject @PageableDefault(size = 20, sort = "date", direction = Sort.Direction.DESC) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        SliceResponse<MyMealReviewResponse> myReviews = reviewServiceV2.findMyReviews(customUserDetails,
+                                                                                      lastReviewId,
+                                                                                      pageable);
+        return BaseResponse.success(myReviews);
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
+++ b/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -101,6 +102,16 @@ public class UserController {
     @DeleteMapping("")
     public BaseResponse<Boolean> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return BaseResponse.success(userService.withdraw(userDetails));
+    }
+    @Operation(summary = "유저 탈퇴 v2", description = "유저 탈퇴 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "유저 탈퇴 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    @DeleteMapping("/v2")
+    public BaseResponse<Boolean> withdrawV2(@RequestParam @NotBlank String nickname, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.withdrawV2(nickname.trim(),userDetails);
+        return BaseResponse.success(true);
     }
 
     @Operation(summary = "내가 쓴 리뷰 리스트 조회", description = "내가 쓴 리뷰 리스트를 조회하는 API 입니다.")

--- a/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
+++ b/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
@@ -216,7 +216,7 @@ public class UserController {
     @Operation(summary = "단과대 조회", description = "숭실대학교 단과대학 들을 조회하는 API입니다.(토큰 불필요)")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "단과대 리스트 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 단과대", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     @GetMapping("/lookup/colleges")
     public BaseResponse<List<GetCollegeResponse>> getColleges() {
@@ -227,7 +227,6 @@ public class UserController {
     @Operation(summary = "단과대에 따른 학과 조회", description = "단과대학을 입력하면 단과대에 속한 숭실대학교 학과를 조회하는 API입니다.(토큰 불필요)")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "단과대 리스트 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     @GetMapping("/lookup/departments")
     public BaseResponse<List<GetDepartmentResponse>> getDepartments(@RequestParam Long collegeId) {

--- a/src/main/java/ssu/eatssu/domain/user/repository/UserRepository.java
+++ b/src/main/java/ssu/eatssu/domain/user/repository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     Optional<User> findByProviderId(String providerId);
+
+    Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import ssu.eatssu.domain.auth.entity.OAuthProvider;
 import ssu.eatssu.domain.auth.security.CustomUserDetails;
+import ssu.eatssu.domain.inquiry.entity.Inquiry;
 import ssu.eatssu.domain.review.entity.Review;
 import ssu.eatssu.domain.user.config.UserProperties;
 import ssu.eatssu.domain.user.department.entity.College;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.DUPLICATE_NICKNAME;
+import static ssu.eatssu.global.handler.response.BaseResponseStatus.INVALID_NICKNAME;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_DEPARTMENT;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_USER;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.VALIDATION_ERROR;
@@ -78,6 +80,20 @@ public class UserService {
         userRepository.delete(user);
 
         return true;
+    }
+
+    public void withdrawV2(String nickName, CustomUserDetails userDetails) {
+        User userCredentials = userRepository.findById(userDetails.getId())
+                                  .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+        User userByNickname = userRepository.findByNickname(nickName).orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+
+        if(!userCredentials.equals(userByNickname)) {
+            throw new BaseException(INVALID_NICKNAME);
+        }
+
+        userCredentials.getReviews().forEach(Review::clearUser);
+        userCredentials.getUserInquiries().forEach(Inquiry::clearUser);
+        userRepository.delete(userCredentials);
     }
 
     public Boolean validateDuplicatedEmail(String email) {

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -83,17 +83,16 @@ public class UserService {
     }
 
     public void withdrawV2(String nickName, CustomUserDetails userDetails) {
-        User userCredentials = userRepository.findById(userDetails.getId())
+        User user = userRepository.findById(userDetails.getId())
                                   .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
-        User userByNickname = userRepository.findByNickname(nickName).orElseThrow(() -> new BaseException(NOT_FOUND_USER));
 
-        if(!userCredentials.equals(userByNickname)) {
+        if (!user.getNickname().equals(nickName)) {
             throw new BaseException(INVALID_NICKNAME);
         }
 
-        userCredentials.getReviews().forEach(Review::clearUser);
-        userCredentials.getUserInquiries().forEach(Inquiry::clearUser);
-        userRepository.delete(userCredentials);
+        user.getReviews().forEach(Review::clearUser);
+        user.getUserInquiries().forEach(Inquiry::clearUser);
+        userRepository.delete(user);
     }
 
     public Boolean validateDuplicatedEmail(String email) {

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -10,9 +10,13 @@ import ssu.eatssu.domain.auth.entity.OAuthProvider;
 import ssu.eatssu.domain.auth.security.CustomUserDetails;
 import ssu.eatssu.domain.review.entity.Review;
 import ssu.eatssu.domain.user.config.UserProperties;
+import ssu.eatssu.domain.user.department.entity.College;
 import ssu.eatssu.domain.user.department.entity.Department;
+import ssu.eatssu.domain.user.department.persistence.CollegeRepository;
 import ssu.eatssu.domain.user.department.persistence.DepartmentRepository;
 import ssu.eatssu.domain.user.dto.DepartmentResponse;
+import ssu.eatssu.domain.user.dto.GetCollegeResponse;
+import ssu.eatssu.domain.user.dto.GetDepartmentResponse;
 import ssu.eatssu.domain.user.dto.MyPageResponse;
 import ssu.eatssu.domain.user.dto.NicknameUpdateRequest;
 import ssu.eatssu.domain.user.dto.UpdateDepartmentRequest;
@@ -20,11 +24,13 @@ import ssu.eatssu.domain.user.entity.User;
 import ssu.eatssu.domain.user.repository.UserRepository;
 import ssu.eatssu.global.handler.response.BaseException;
 
+import java.util.List;
 import java.util.UUID;
 
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.DUPLICATE_NICKNAME;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_DEPARTMENT;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_USER;
+import static ssu.eatssu.global.handler.response.BaseResponseStatus.VALIDATION_ERROR;
 
 @Slf4j
 @Service
@@ -37,6 +43,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final DepartmentRepository departmentRepository;
     private final UserProperties userProperties;
+    private final CollegeRepository collegeRepository;
 
     public User join(String email, OAuthProvider provider, String providerId) {
         String credentials = createCredentials(provider, providerId);
@@ -109,6 +116,26 @@ public class UserService {
                                   .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
         Department department = user.getDepartment();
         return new DepartmentResponse(department != null ? department.getName() : "");
+    }
+
+    public List<GetCollegeResponse> getCollegeList() {
+        List<College> colleges = collegeRepository.findAll();
+        return colleges.stream().map(college -> GetCollegeResponse.builder()
+                                                                  .id(college.getId())
+                                                                  .name(college.getName())
+                                                                  .build())
+                       .toList();
+    }
+
+    public List<GetDepartmentResponse> getDepartmentList(Long collegeId) {
+        College college = collegeRepository.findById(collegeId)
+                                           .orElseThrow(() -> new BaseException(VALIDATION_ERROR));
+        List<Department> departments = departmentRepository.findByCollege(college);
+        return departments.stream().map(department -> GetDepartmentResponse.builder()
+                                                                  .id(department.getId())
+                                                                  .name(department.getName())
+                                                                  .build())
+                       .toList();
     }
 
     private boolean isForbiddenNickname(String nickname) {

--- a/src/main/java/ssu/eatssu/global/handler/response/BaseResponseStatus.java
+++ b/src/main/java/ssu/eatssu/global/handler/response/BaseResponseStatus.java
@@ -59,6 +59,7 @@ public enum BaseResponseStatus {
     NOT_FOUND_DEPARTMENT(false, HttpStatus.NOT_FOUND, 40409, "해당 학과를 찾을 수 없습니다."),
     NOT_FOUND_PARTNERSHIP(false, HttpStatus.NOT_FOUND, 40410, "해당 제휴를 찾을 수 없습니다."),
     NOT_FOUND_PARTNERSHIP_RESTAURANT(false, HttpStatus.NOT_FOUND, 40411, "해당 제휴 식당을 찾을 수 없습니다."),
+    INVALID_NICKNAME(false,HttpStatus.NOT_FOUND,40412,"잘못된 닉네임입니다."),
 
     /**
      * 405 METHOD_NOT_ALLOWED 지원하지 않은 method 호출

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -41,8 +41,8 @@ spring:
 jwt:
   secret:
     key: ${EATSSU_JWT_SECRET_DEV}
-  token-validity-in-seconds: 60
-  refresh-token-validity-in-seconds: 180
+  token-validity-in-seconds: 86400
+  refresh-token-validity-in-seconds: 604800
 
 #S3
 cloud:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -29,8 +29,8 @@ spring:
 jwt:
   secret:
     key: ${EATSSU_JWT_SECRET_LOCAL}
-  token-validity-in-seconds: 10
-  refresh-token-validity-in-seconds: 30
+  token-validity-in-seconds: 86400
+  refresh-token-validity-in-seconds: 604800
 
 cloud:
   aws:


### PR DESCRIPTION
## #️⃣ Issue Number

- #210
<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 마이페이지 리뉴얼로 추가, 수정된 기능들을 보완했습니다.
- 단과대와 학과 조회 api를 개발했습니다.
  - db에 있는 값을 조회하여, 단과대 id로 학과 조회를 할 수 있도록 변경했습니다.
  - 기존 프론트 하드코딩 로직들을 개선하기 위함입니다.
- 유저 탈퇴 api 
 - 피그마 화면대로 유저에게 닉네임을 입력받고 -> 닉네임 일치 시 -> 탈퇴로직 수행으로 변경했습니다.
- 내가 쓴 리뷰 확인 API
 - 해당 API는 기존` /v2/reviews/my`와 일치합니다.

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
