### PR TITLE
[FEATURE] 250818 수정사항 중, 제휴지도 관련 건 수정

### DIFF
--- a/src/main/java/ssu/eatssu/domain/partnership/entity/Partnership.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/Partnership.java
@@ -26,7 +26,7 @@ import java.time.LocalDate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-@Where(clause = "end_date >= CURRENT_DATE")
+@Where(clause = "start_date <= CURRENT_DATE AND end_date >= CURRENT_DATE")
 public class Partnership {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ssu/eatssu/domain/partnership/persistence/PartnershipRepository.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/persistence/PartnershipRepository.java
@@ -4,16 +4,29 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import ssu.eatssu.domain.partnership.entity.Partnership;
+import ssu.eatssu.domain.partnership.entity.PartnershipRestaurant;
 import ssu.eatssu.domain.user.department.entity.College;
 import ssu.eatssu.domain.user.department.entity.Department;
 
 import java.util.List;
 
 public interface PartnershipRepository extends JpaRepository<Partnership, Long> {
-    @Query("SELECT DISTINCT p FROM Partnership p " +
-            "LEFT JOIN p.partnershipCollege pc " +
-            "LEFT JOIN p.partnershipDepartment pd " +
-            "WHERE (pc = :college OR pd = :department OR (pc IS NOT NULL AND pc.name = '총학')) and CURRENT_DATE BETWEEN p.startDate AND p.endDate")
-    List<Partnership> findRelevantPartnerships(@Param("college") College college,
-                                               @Param("department") Department department);
+    @Query("""
+            select distinct pr
+            from PartnershipRestaurant pr
+            join fetch pr.partnerships p
+            left join fetch p.partnershipCollege pc
+            left join fetch p.partnershipDepartment pd
+            where
+              (pc = :college
+               or pd = :department
+               or (pc is not null and pc.name = '총학'))
+              and p.startDate <= current_date
+              and (p.endDate is null or p.endDate >= current_date)
+            """)
+    List<PartnershipRestaurant> findRestaurantsWithMyPartnerships(
+            @Param("college") College college,
+            @Param("department") Department department
+                                                                 );
+
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/persistence/PartnershipRepository.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/persistence/PartnershipRepository.java
@@ -13,7 +13,7 @@ public interface PartnershipRepository extends JpaRepository<Partnership, Long> 
     @Query("SELECT DISTINCT p FROM Partnership p " +
             "LEFT JOIN p.partnershipCollege pc " +
             "LEFT JOIN p.partnershipDepartment pd " +
-            "WHERE (pc = :college OR pd = :department OR (pc IS NOT NULL AND pc.name = '총학'))")
+            "WHERE (pc = :college OR pd = :department OR (pc IS NOT NULL AND pc.name = '총학')) and CURRENT_DATE BETWEEN p.startDate AND p.endDate")
     List<Partnership> findRelevantPartnerships(@Param("college") College college,
                                                @Param("department") Department department);
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/persistence/PartnershipRestaurantRepository.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/persistence/PartnershipRestaurantRepository.java
@@ -10,6 +10,7 @@ public interface PartnershipRestaurantRepository extends JpaRepository<Partnersh
     @Query("SELECT DISTINCT pr FROM PartnershipRestaurant pr " +
             "LEFT JOIN FETCH pr.partnerships p " +
             "LEFT JOIN FETCH p.partnershipCollege " +
-            "LEFT JOIN FETCH p.partnershipDepartment ")
+            "LEFT JOIN FETCH p.partnershipDepartment " +
+            "WHERE CURRENT_DATE BETWEEN p.startDate AND p.endDate")
     List<PartnershipRestaurant> findAllWithDetails();
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/persistence/PartnershipRestaurantRepository.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/persistence/PartnershipRestaurantRepository.java
@@ -7,10 +7,11 @@ import ssu.eatssu.domain.partnership.entity.PartnershipRestaurant;
 import java.util.List;
 
 public interface PartnershipRestaurantRepository extends JpaRepository<PartnershipRestaurant, Long> {
-    @Query("SELECT DISTINCT pr FROM PartnershipRestaurant pr " +
-            "LEFT JOIN FETCH pr.partnerships p " +
-            "LEFT JOIN FETCH p.partnershipCollege " +
-            "LEFT JOIN FETCH p.partnershipDepartment "+
-            "WHERE p.startDate <= CURRENT_DATE and (p.endDate is null or p.endDate >= CURRENT_DATE)")
+    @Query("""
+            SELECT DISTINCT pr FROM PartnershipRestaurant pr
+            LEFT JOIN FETCH pr.partnerships p
+            LEFT JOIN FETCH p.partnershipCollege
+            LEFT JOIN FETCH p.partnershipDepartment
+            WHERE p.startDate <= CURRENT_DATE and (p.endDate is null or p.endDate >= CURRENT_DATE)""")
     List<PartnershipRestaurant> findAllWithDetails();
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/persistence/PartnershipRestaurantRepository.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/persistence/PartnershipRestaurantRepository.java
@@ -10,7 +10,7 @@ public interface PartnershipRestaurantRepository extends JpaRepository<Partnersh
     @Query("SELECT DISTINCT pr FROM PartnershipRestaurant pr " +
             "LEFT JOIN FETCH pr.partnerships p " +
             "LEFT JOIN FETCH p.partnershipCollege " +
-            "LEFT JOIN FETCH p.partnershipDepartment " +
-            "WHERE CURRENT_DATE BETWEEN p.startDate AND p.endDate")
+            "LEFT JOIN FETCH p.partnershipDepartment "+
+            "WHERE p.startDate <= CURRENT_DATE and (p.endDate is null or p.endDate >= CURRENT_DATE)")
     List<PartnershipRestaurant> findAllWithDetails();
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/service/PartnershipService.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/service/PartnershipService.java
@@ -115,14 +115,10 @@ public class PartnershipService {
         College college = department.getCollege();
 
         return partnershipRepository
-                .findRelevantPartnerships(college, department)
+                .findRestaurantsWithMyPartnerships(college, department)
                 .stream()
-                .map(partnership -> {
-                    PartnershipRestaurant partnershipRestaurant = partnership.getPartnershipRestaurant();
-
-                    return PartnershipResponse.fromEntity(partnershipRestaurant,
-                                                          customUserDetails.getId());
-                })
+                .map(partnership -> PartnershipResponse.fromEntity(partnership,
+                                                               customUserDetails.getId()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/service/PartnershipService.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/service/PartnershipService.java
@@ -117,8 +117,8 @@ public class PartnershipService {
         return partnershipRepository
                 .findRestaurantsWithMyPartnerships(college, department)
                 .stream()
-                .map(partnership -> PartnershipResponse.fromEntity(partnership,
-                                                               customUserDetails.getId()))
+                .map(partnershipRestaurant -> PartnershipResponse.fromEntity(partnershipRestaurant,
+                                                                             customUserDetails.getId()))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/department/persistence/DepartmentRepository.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/persistence/DepartmentRepository.java
@@ -4,14 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import ssu.eatssu.domain.user.department.entity.College;
 import ssu.eatssu.domain.user.department.entity.Department;
 
-import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
 
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
     Optional<Department> findByName(String name);
-
-    Optional<Department> findById(Long id);
 
     List<Department> findByCollege(College college);
 }

--- a/src/main/java/ssu/eatssu/domain/user/department/persistence/DepartmentRepository.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/persistence/DepartmentRepository.java
@@ -4,11 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import ssu.eatssu.domain.user.department.entity.College;
 import ssu.eatssu.domain.user.department.entity.Department;
 
+import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
 
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
     Optional<Department> findByName(String name);
+
+    Optional<Department> findById(Long id);
 
     List<Department> findByCollege(College college);
 }

--- a/src/main/java/ssu/eatssu/domain/user/dto/DepartmentResponse.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/DepartmentResponse.java
@@ -1,10 +1,24 @@
 package ssu.eatssu.domain.user.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Builder;
+import ssu.eatssu.domain.user.department.entity.College;
+import ssu.eatssu.domain.user.department.entity.Department;
 
-@Getter
-@AllArgsConstructor
-public class DepartmentResponse {
-    private String departmentName;
+@Builder
+public record DepartmentResponse(
+        Long departmentId, String departmentName, Long collegeId, String collegeName
+) {
+    public static DepartmentResponse from(Department department) {
+        if (department == null) {
+            return new DepartmentResponse(null, null, null, null);
+        }
+        final College college = department.getCollege();
+        return DepartmentResponse.builder()
+                                 .departmentId(department.getId())
+                                 .departmentName(department.getName())
+                                 .collegeId(college != null ? college.getId() : null)
+                                 .collegeName(college != null ? college.getName() : null)
+                                 .build();
+    }
 }
+

--- a/src/main/java/ssu/eatssu/domain/user/dto/MyPageResponse.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/MyPageResponse.java
@@ -5,15 +5,49 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import ssu.eatssu.domain.auth.entity.OAuthProvider;
+import ssu.eatssu.domain.user.department.entity.College;
+import ssu.eatssu.domain.user.department.entity.Department;
+import ssu.eatssu.domain.user.entity.User;
 
 @AllArgsConstructor
 @Builder
 @Schema(title = "마이페이지 정보")
 @Getter
 public class MyPageResponse {
+
     @Schema(description = "닉네임", example = "피치푸치")
     private String nickname;
 
-    @Schema(description = "연결 계정 정보", example = "피치푸치")
+    @Schema(description = "연결 계정 정보", example = "GOOGLE")
     private OAuthProvider provider;
+
+    @Schema(description = "학과 id", example = "1")
+    private Long departmentId;
+
+    @Schema(description = "학과 이름", example = "컴퓨터학부")
+    private String departmentName;
+
+    @Schema(description = "단과대 id", example = "1")
+    private Long collegeId;
+
+    @Schema(description = "단과대 이름", example = "IT 대학")
+    private String collegeName;
+
+    public static MyPageResponse from(User user) {
+        if (user == null) {
+            return MyPageResponse.builder().build();
+        }
+
+        Department department = user.getDepartment();
+        College college = department != null ? department.getCollege() : null;
+
+        return MyPageResponse.builder()
+                             .nickname(user.getNickname())
+                             .provider(user.getProvider())
+                             .departmentId(department != null ? department.getId() : null)
+                             .departmentName(department != null ? department.getName() : null)
+                             .collegeId(college != null ? college.getId() : null)
+                             .collegeName(college != null ? college.getName() : null)
+                             .build();
+    }
 }

--- a/src/main/java/ssu/eatssu/domain/user/dto/UpdateDepartmentRequest.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/UpdateDepartmentRequest.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class UpdateDepartmentRequest {
-    @Schema(description = "학과 이름", example = "소프트")
-    private String departmentName;
+    @Schema(description = "학과 id", example = "1")
+    private Long departmentId;
 }

--- a/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
+++ b/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -102,16 +101,6 @@ public class UserController {
     @DeleteMapping("")
     public BaseResponse<Boolean> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return BaseResponse.success(userService.withdraw(userDetails));
-    }
-    @Operation(summary = "유저 탈퇴 v2", description = "유저 탈퇴 API 입니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "유저 탈퇴 성공"),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
-    })
-    @DeleteMapping("/v2")
-    public BaseResponse<Boolean> withdrawV2(@RequestParam @NotBlank String nickname, @AuthenticationPrincipal CustomUserDetails userDetails) {
-        userService.withdrawV2(nickname.trim(),userDetails);
-        return BaseResponse.success(true);
     }
 
     @Operation(summary = "내가 쓴 리뷰 리스트 조회", description = "내가 쓴 리뷰 리스트를 조회하는 API 입니다.")

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -68,7 +68,7 @@ public class UserService {
     public MyPageResponse findMyPage(CustomUserDetails userDetails) {
         User user = userRepository.findById(userDetails.getId())
                                   .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
-        return new MyPageResponse(user.getNickname(), user.getProvider());
+        return MyPageResponse.from(user);
     }
 
     public boolean withdraw(CustomUserDetails userDetails) {

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -129,8 +129,7 @@ public class UserService {
     public DepartmentResponse getDepartment(CustomUserDetails userDetails) {
         User user = userRepository.findById(userDetails.getId())
                                   .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
-        Department department = user.getDepartment();
-        return new DepartmentResponse(department != null ? department.getName() : "");
+        return DepartmentResponse.from(user.getDepartment());
     }
 
     public List<GetCollegeResponse> getCollegeList() {

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import ssu.eatssu.domain.auth.entity.OAuthProvider;
 import ssu.eatssu.domain.auth.security.CustomUserDetails;
-import ssu.eatssu.domain.inquiry.entity.Inquiry;
 import ssu.eatssu.domain.review.entity.Review;
 import ssu.eatssu.domain.user.config.UserProperties;
 import ssu.eatssu.domain.user.department.entity.College;
@@ -29,7 +28,6 @@ import java.util.List;
 import java.util.UUID;
 
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.DUPLICATE_NICKNAME;
-import static ssu.eatssu.global.handler.response.BaseResponseStatus.INVALID_NICKNAME;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_DEPARTMENT;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_USER;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.VALIDATION_ERROR;
@@ -80,19 +78,6 @@ public class UserService {
         userRepository.delete(user);
 
         return true;
-    }
-
-    public void withdrawV2(String nickName, CustomUserDetails userDetails) {
-        User user = userRepository.findById(userDetails.getId())
-                                  .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
-
-        if (!user.getNickname().equals(nickName)) {
-            throw new BaseException(INVALID_NICKNAME);
-        }
-
-        user.getReviews().forEach(Review::clearUser);
-        user.getUserInquiries().forEach(Inquiry::clearUser);
-        userRepository.delete(user);
     }
 
     public Boolean validateDuplicatedEmail(String email) {

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -120,7 +120,7 @@ public class UserService {
     public void registerDepartment(UpdateDepartmentRequest request, CustomUserDetails userDetails) {
         User user = userRepository.findById(userDetails.getId())
                                   .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
-        Department department = departmentRepository.findByName(request.getDepartmentName())
+        Department department = departmentRepository.findById(request.getDepartmentId())
                                                     .orElseThrow(() -> new BaseException(NOT_FOUND_DEPARTMENT));
 
         user.updateDepartment(department);


### PR DESCRIPTION
## #️⃣ Issue Number

- #212 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- 250818 회의 중, 제휴지도 요청건이 가장 우선순위가 높아보여 먼저 수정했습니다.
- [제휴지도] POST [/users/department](https://dev.eat-ssu.store/swagger-ui/index.html#/User/registerDepartment) 유저의 학과 등록 이 API에서 request도 학과 name(예를들어 “소프트웨어학부”)가 아닌 학과 id로 보내게끔 수정🚨 
- [제휴지도] /users/department api에 department, college 정보 둘다 주고 id와 name둘다 주게끔 수정🚨
- [마이페이지] users/mypage에 학과,단과대 정보도 추가! 🚨
- [제휴지도] 제휴기간에 안맞으면 서버에서 유효성 검사하게 SQL문 수정🚨

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
