### PR TITLE
fix: 에러 헨들러에서 500대 에러만 보내도록 수정

### DIFF
--- a/src/main/java/ssu/eatssu/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/ssu/eatssu/global/handler/GlobalExceptionHandler.java
@@ -46,7 +46,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
      */
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<BaseResponse<Void>> handleBaseException(BaseException e) {
-        slackErrorNotifier.notify(e);
+        if(BaseResponseStatus.sendSlackNotification(e.getStatus())){
+            slackErrorNotifier.notify(e);
+        }
         return ResponseEntity.status(e.getStatus().getHttpStatus()).body(BaseResponse.fail(e.getStatus()));
     }
 

--- a/src/main/java/ssu/eatssu/global/handler/response/BaseResponseStatus.java
+++ b/src/main/java/ssu/eatssu/global/handler/response/BaseResponseStatus.java
@@ -105,4 +105,8 @@ public enum BaseResponseStatus {
         this.code = code;
         this.message = message;
     }
+
+    public static boolean sendSlackNotification(BaseResponseStatus baseResponseStatus) {
+        return baseResponseStatus.httpStatus.is5xxServerError();
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- #215 

## 📝 요약(Summary)
- 500대 에러만 Slack으로 알림이 오도록 수정했습니다.

## 💬 공유사항 to 리뷰어
<img width="1573" height="861" alt="스크린샷 2025-09-01 오후 5 41 28" src="https://github.com/user-attachments/assets/87e0f9f3-0787-4e76-a9e7-e36914588339" />

- main에 해당 이슈와 관련된 사항이 수정이 되어 있었으나, Error handler에서도 알림이 가는 부분을 수정했습니다.


## ✅ PR Checklist

- [ ] Slack 알림 조건이 변경될 것을 고려해서 Enum에서 요구 조건을 처리하도록 구현했습니다.