### PR TITLE
fix: 리뷰 조회에서 isWriter가 항상 false로 나오는 문제 해결

### DIFF
--- a/src/main/java/ssu/eatssu/domain/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/ssu/eatssu/domain/auth/security/JwtAuthenticationFilter.java
@@ -45,6 +45,11 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         String requestURI = httpRequest.getRequestURI();
 
         if (isWhiteListed(requestURI)) {
+            String token = resolveToken(httpRequest);
+            if (token != null && jwtTokenProvider.validateToken(token)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ server:
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://eatssu-db.cf0ackgagqzb.ap-northeast-2.rds.amazonaws.com/dev
+    url: ${EATSSU_DB_URL_DEV}
     username: admin
     password: ssu2023!
 


### PR DESCRIPTION
선택적으로 토큰을 받을 수 있돌고 수정

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

- #224 

## 📝 요약(Summary)

- JwtAuthenticationFilter에서 White List에 속한 API들은 인증 정보 없이 호출이 가능합니다.

v1 Review 리스트 조회 API의 경우에도 여기에 속해 있었고 이로 인해서 Security Context에 유저 정보가 들어가지 않았습니다.
이런 이유로 모든 리뷰의 isWriter가 false로 나오는 현상이 발생했습니다.

- 따라서, White List에 속한 API들도 선택적으로 토큰을 주입할 경우 UserDetails를 생성하도록 수정했습니다.

## 💬 공유사항 to 리뷰어

-  리뷰 리스트 조회만을 위한 별도의 filter chain을 만드는 것보다는 현재 구조를 선택했습니다!
