### PR TITLE
fix: rating 산출방식 meal에 해당하는 menu 모아서 산출하게 변경

### DIFF
--- a/src/main/java/ssu/eatssu/domain/review/dto/MealReviewResponse.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/MealReviewResponse.java
@@ -31,7 +31,7 @@ public class MealReviewResponse {
     private String writerNickname;
 
     @Schema(description = "평점", example = "4")
-    private Integer rating;
+    private Double rating;
 
     @Schema(description = "리뷰 작성 날짜(format = yyyy-MM-dd)", example = "2023-04-07")
     private LocalDate writtenAt;
@@ -60,7 +60,7 @@ public class MealReviewResponse {
 
     public static MealReviewResponse from(Review review,
                                           Long userId,
-                                          List<ValidMenuForViewResponse.MenuDto> validMenus) {
+                                          List<ValidMenuForViewResponse.MenuDto> validMenus,Double rating) {
         List<String> imageUrls = new ArrayList<>();
         review.getReviewImages().forEach(i -> imageUrls.add(i.getImageUrl()));
 
@@ -77,10 +77,9 @@ public class MealReviewResponse {
                                                               likedMenuIds.contains(valid.getMenuId())
                                                       ))
                                                       .toList();
-
         MealReviewResponseBuilder builder = MealReviewResponse.builder()
                                                               .reviewId(review.getId())
-                                                              .rating(review.getRating())
+                                                              .rating(rating)
                                                               .writtenAt(review.getCreatedDate().toLocalDate())
                                                               .content(review.getContent())
                                                               .imageUrls(imageUrls)


### PR DESCRIPTION
## #️⃣ Issue Number

- #279 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

- rating의 경우, meal에 해당하는 모든 menu들을 모아서 평균 rating을 산출하게 변경했습니다. rating은 v1,v2모두 같은 산출 방식을 사용합니다.

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
