### PR TITLE
fix: 로그인 통합

### DIFF
--- a/src/main/java/ssu/eatssu/domain/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/ssu/eatssu/domain/auth/security/CustomUserDetailsService.java
@@ -17,9 +17,10 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
 
+    // OrderByIdAsc로 해줌으로써 처음 생성된 계정으로 연결된다.
     @Override
     public UserDetails loadUserByUsername(String username) {
-        User user = userRepository.findByEmail(username)
+        User user = userRepository.findFirstByEmailOrderByIdAsc(username)
                                   .orElseThrow(() -> new BaseException(BaseResponseStatus.NOT_FOUND_USER));
         return new CustomUserDetails(user);
     }

--- a/src/main/java/ssu/eatssu/domain/auth/service/OAuthService.java
+++ b/src/main/java/ssu/eatssu/domain/auth/service/OAuthService.java
@@ -34,7 +34,8 @@ public class OAuthService {
 
     public Tokens kakaoLogin(KakaoLoginRequest request) {
         User user = userRepository.findByProviderId(request.providerId())
-                                  .orElseGet(() -> userService.join(request.email(), KAKAO, request.providerId()));
+                                  .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(request.email())
+                                          .orElseGet(() -> userService.join(request.email(), KAKAO, request.providerId())));
 
         return generateOauthJwtTokens(user.getEmail(), KAKAO, request.providerId());
     }
@@ -44,7 +45,8 @@ public class OAuthService {
      */
     public Tokens kakaoLoginV2(KakaoLoginRequestV2 request) {
         User user = userRepository.findByProviderId(request.providerId())
-                .orElseGet(() -> userService.joinV2(request.email(), KAKAO, request.providerId(),request.deviceType()));
+                .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(request.email())
+                        .orElseGet(() -> userService.joinV2(request.email(), KAKAO, request.providerId(),request.deviceType())));
 
         user.updateDeviceType(request.deviceType());
 
@@ -57,7 +59,8 @@ public class OAuthService {
         OAuthInfo oAuthInfo = appleAuthenticator.getOAuthInfoByIdentityToken(request.identityToken());
 
         User user = userRepository.findByProviderId(oAuthInfo.providerId())
-                                  .orElseGet(() -> userService.join(oAuthInfo.email(), APPLE, oAuthInfo.providerId()));
+                                  .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(oAuthInfo.email())
+                                          .orElseGet(() -> userService.join(oAuthInfo.email(), APPLE, oAuthInfo.providerId())));
 
         updateAppleUserEmail(user, oAuthInfo.email());
 
@@ -71,7 +74,8 @@ public class OAuthService {
         OAuthInfo oAuthInfo = appleAuthenticator.getOAuthInfoByIdentityToken(request.identityToken());
 
         User user = userRepository.findByProviderId(oAuthInfo.providerId())
-                .orElseGet(() -> userService.joinV2(oAuthInfo.email(), APPLE, oAuthInfo.providerId(),request.deviceType()));
+                .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(oAuthInfo.email())
+                        .orElseGet(() -> userService.joinV2(oAuthInfo.email(), APPLE, oAuthInfo.providerId(),request.deviceType())));
 
         updateAppleUserEmail(user, oAuthInfo.email());
 

--- a/src/main/java/ssu/eatssu/domain/user/repository/UserRepository.java
+++ b/src/main/java/ssu/eatssu/domain/user/repository/UserRepository.java
@@ -13,9 +13,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByNickname(String nickname);
 
-    Optional<User> findByEmail(String email);
-
     Optional<User> findByProviderId(String providerId);
 
-    Optional<User> findByNickname(String nickname);
+    Optional<User> findFirstByEmailOrderByIdAsc(String email);
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
- #338 

## 📝 요약(Summary)
- 기존에 로그인 통합이  제대로 작동하지 않는 문제를 해결했습니다.

## 💬 공유사항 to 리뷰어
AS-IS
- 로그인을 하는 경우 기존에는 `providerId`를 식별자로 사용하고 있었습니다.
- 플렛폼은 다르지만, 이메일이 같은 경우 uk로 인해서 회원가입이 실패하는 현상이 있었습니다.

저번 작업에서는...
- 이메일의 uk를 해제한다. (이미 완료)
이로 인해서 별도의 계정으로 취급이 될 것을 기대했으나, 로그인이 되지 않는 문제 발생.

<img width="973" height="274" alt="스크린샷 2026-02-01 오후 11 07 01" src="https://github.com/user-attachments/assets/2a4a8349-5693-4389-80b7-80853bc4510c" />

문제의 원인은 
<img width="850" height="306" alt="스크린샷 2026-02-01 오후 11 07 27" src="https://github.com/user-attachments/assets/a5c33955-6ef4-439c-91ea-922d8602016c" />
JWT 토큰을 생성하는 과정에서 내부적으로

<img width="919" height="360" alt="스크린샷 2026-02-01 오후 11 09 15" src="https://github.com/user-attachments/assets/9f31fa79-3add-4ad9-9fd2-f5dcc42b8b6c" />

이메일로 유저를 식별하고 있었음.

이 과정에서 2개의 플렛폼에서 같은 이메일로 가입을 한 사람은 단일 결과가 반환되지 않아서 에러가 터졌다.

TO-BE
- 진님의 의견에 따라서 카카오와 애플에서 이메일이 같은 경우 2개의 계정이 아닌 하나의 계정으로 로그인 되도록 구현할 것입니다.
- ⭐ 하지만, 이미 같은 이메일을 가진 다른 플렛폼의 계정을 가진 유저가 존재하는 상태이므로 `하위호환성`을 보장해줄 필요가 있다.

```
public Tokens appleLogin(AppleLoginRequest request) {
    OAuthInfo oAuthInfo = appleAuthenticator.getOAuthInfoByIdentityToken(request.identityToken());

    User user = userRepository.findByProviderId(oAuthInfo.providerId())
                              .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(oAuthInfo.email())
                                      .orElseGet(() -> userService.join(oAuthInfo.email(), APPLE, oAuthInfo.providerId())));

    updateAppleUserEmail(user, oAuthInfo.email());

    return generateOauthJwtTokens(user.getEmail(), APPLE, oAuthInfo.providerId());
}
```
따라서, userRepository에서 `findByEmail`이 아닌 `findFirstByEmailOrderByIdAsc`을 사용한다. 여러 계정이 생성된 사람이라면 id값이 작은 먼저 생성된 계정을 조회할 것이고. 아직 계정이 생성되지 않은 유저라면 기존 의도대로 이메일이 같은 다른 플렛폼의 계정으로 로그인이 가능하다.

추가적으로, 
- 플렛폼은 다른데 이메일이 같은 유저가 로그인 시도를 하고 계정은 생성했지만, generateOauthJwtTokens에서 실패를 했음으로 로그인은 실패했을 것이기 때문에 리뷰를 연동해줄 필요는 없다고 느꼈습니다.
- 이제부터 하나의 계정으로 로그인이 될 것이기 때문.


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
