### PR TITLE
fix: Apple 재로그인 시 email 없는 경우 providerId로 기존 유저 조회

### DIFF
--- a/src/main/java/ssu/eatssu/domain/auth/entity/SystemAppleAuthenticator.java
+++ b/src/main/java/ssu/eatssu/domain/auth/entity/SystemAppleAuthenticator.java
@@ -14,6 +14,7 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import ssu.eatssu.domain.auth.dto.AppleKeys;
 import ssu.eatssu.domain.auth.dto.OAuthInfo;
+import ssu.eatssu.domain.user.entity.User;
 import ssu.eatssu.domain.user.repository.UserRepository;
 import ssu.eatssu.global.handler.response.BaseException;
 
@@ -68,17 +69,10 @@ public class SystemAppleAuthenticator implements AppleAuthenticator {
 
         // email 없는 경우 → Apple 재로그인 케이스 검증 (Apple 스펙상 최초 로그인 시에만 email 포함)
         if (emailObj == null) {
-            boolean existsUser = userRepository.findByProviderId(providerId).isPresent();
-
-            if (existsUser) {
-                // 가설 맞음: 기존 유저 재로그인 케이스 → 슬랙 알럿으로 확인
-                log.warn("[Apple Login] email claim 없음 & DB 유저 있음. 재로그인 케이스로 확인. providerId={}", providerId);
-                throw new BaseException(NOT_FOUND_EMAIL);
-            } else {
-                // 다른 원인: 신규 유저인데 email 없음 → 슬랙 알럿으로 별도 구분
-                log.warn("[Apple Login] email claim 없음 & DB 유저 없음. 원인 불명. providerId={}", providerId);
-                throw new BaseException(NOT_FOUND_APPLE_EMAIL_NEW_USER);
-            }
+            log.info("[Apple Login] email claim 없음. providerId={}로 기존 유저 조회 시도", providerId);
+            User existingUser = userRepository.findByProviderId(providerId)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_APPLE_EMAIL_NEW_USER));
+            return new OAuthInfo(existingUser.getEmail(), providerId);
         }
 
         String email = emailObj.toString();

--- a/src/main/java/ssu/eatssu/domain/auth/entity/SystemAppleAuthenticator.java
+++ b/src/main/java/ssu/eatssu/domain/auth/entity/SystemAppleAuthenticator.java
@@ -7,14 +7,12 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 import ssu.eatssu.domain.auth.dto.AppleKeys;
 import ssu.eatssu.domain.auth.dto.OAuthInfo;
-import ssu.eatssu.domain.user.entity.User;
 import ssu.eatssu.domain.user.repository.UserRepository;
 import ssu.eatssu.global.handler.response.BaseException;
 
@@ -32,7 +30,6 @@ import static ssu.eatssu.global.handler.response.BaseResponseStatus.*;
 
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class SystemAppleAuthenticator implements AppleAuthenticator {
 
     private final RestTemplate restTemplate;
@@ -67,16 +64,14 @@ public class SystemAppleAuthenticator implements AppleAuthenticator {
 
         String providerId = providerIdObj.toString();
 
-        // email 없는 경우 → Apple 재로그인 케이스 검증 (Apple 스펙상 최초 로그인 시에만 email 포함)
+        // email 없는 경우 → Apple 재로그인 케이스 (Apple 스펙상 최초 로그인 시에만 email 포함)
         if (emailObj == null) {
-            log.info("[Apple Login] email claim 없음. providerId={}로 기존 유저 조회 시도", providerId);
-            User existingUser = userRepository.findByProviderId(providerId)
+            return userRepository.findByProviderId(providerId)
+                .map(user -> new OAuthInfo(user.getEmail(), providerId))
                 .orElseThrow(() -> new BaseException(NOT_FOUND_APPLE_EMAIL_NEW_USER));
-            return new OAuthInfo(existingUser.getEmail(), providerId);
         }
 
-        String email = emailObj.toString();
-        return new OAuthInfo(email, providerId);
+        return new OAuthInfo(emailObj.toString(), providerId);
     }
 
     private PublicKey generatePublicKey(String identityToken) {


### PR DESCRIPTION
## #️⃣ Issue Number

#346 

## 📝 요약(Summary)

Apple 스펙상 identityToken의 `email` 클레임은 최초 로그인 시에만 포함되고, 재로그인 시에는 포함되지 않았음.
기존 코드는 email이 null이면 무조건 에러를 던지고 있어서, 기존 유저가 재로그인할 때도 튕기는 문제가 발생.

슬랙 알럿 확인 결과, Apple 로그인 에러 전부 `NOT_FOUND_EMAIL`(40414)이고`NOT_FOUND_APPLE_EMAIL_NEW_USER`(40415)는 0건으로, 기존 유저 재로그인 케이스로 확정됨.

## 💬 공유사항 to 리뷰어

 - `OAuthService` 쪽은 변경 없이 기존 flow 그대로 동작함.
 - 신규 유저인데 email이 없는 비정상 케이스는 `NOT_FOUND_APPLE_EMAIL_NEW_USER`(40415) 에러를 유지함.

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
