### PR TITLE
fix: 리뷰v2 - menu 리뷰 작성시 menuLike가 null일때 발생하는 NPE을 방지해요

### DIFF
--- a/src/main/java/ssu/eatssu/domain/review/dto/CreateMenuReviewRequestV2.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/CreateMenuReviewRequestV2.java
@@ -1,8 +1,10 @@
 package ssu.eatssu.domain.review.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import ssu.eatssu.domain.menu.entity.Menu;
@@ -16,10 +18,13 @@ import java.util.List;
 @AllArgsConstructor
 public class CreateMenuReviewRequestV2 {
     @Schema(description = "평점", example = "5")
+    @NotNull
     @Min(1)
     @Max(5)
     private Integer rating;
 
+    @NotNull
+    @Valid
     private MenuLikeRequest menuLike;
 
     @Schema(description = "한줄평", example = "이 메뉴 진짜 맛있어요!")

--- a/src/main/java/ssu/eatssu/domain/review/dto/MenuLikeRequest.java
+++ b/src/main/java/ssu/eatssu/domain/review/dto/MenuLikeRequest.java
@@ -1,6 +1,7 @@
 package ssu.eatssu.domain.review.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,6 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class MenuLikeRequest {
     @Schema(description = "메뉴 식별자", example = "123")
+    @NotNull
     private Long menuId;
     @Schema(description = "좋아요 선택", example = "좋아요 : true (기본값은 false)")
     private Boolean isLike;

--- a/src/main/java/ssu/eatssu/domain/review/service/ReviewServiceV2.java
+++ b/src/main/java/ssu/eatssu/domain/review/service/ReviewServiceV2.java
@@ -51,6 +51,7 @@ import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_ME
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_MENU;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_REVIEW;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_USER;
+import static ssu.eatssu.global.handler.response.BaseResponseStatus.FAILED_VALIDATION;
 import static ssu.eatssu.global.handler.response.BaseResponseStatus.REVIEW_PERMISSION_DENIED;
 
 @Slf4j
@@ -78,12 +79,18 @@ public class ReviewServiceV2 {
 
         Review review = request.toReviewEntity(user, meal);
 
-        request.getImageUrls().forEach(review::addReviewImage);
+        List<String> imageUrls = Optional.ofNullable(request.getImageUrls()).orElse(Collections.emptyList());
+        imageUrls.forEach(review::addReviewImage);
 
-        for (MenuLikeRequest menuLike : request.getMenuLikes()) {
+        List<MenuLikeRequest> menuLikes = Optional.ofNullable(request.getMenuLikes()).orElse(Collections.emptyList());
+        for (MenuLikeRequest menuLike : menuLikes) {
+            if (menuLike == null || menuLike.getMenuId() == null) {
+                throw new BaseException(FAILED_VALIDATION);
+            }
             Menu menu = menuRepository.findById(menuLike.getMenuId())
                     .orElseThrow(() -> new BaseException(NOT_FOUND_MENU));
-            review.addReviewMenuLike(menu, menuLike.getIsLike());
+            boolean isLike = Boolean.TRUE.equals(menuLike.getIsLike());
+            review.addReviewMenuLike(menu, isLike);
         }
 
         reviewRepository.save(review);
@@ -93,8 +100,8 @@ public class ReviewServiceV2 {
                         review.getId(),
                         meal.getId(),
                         user.getId(),
-                        request.getImageUrls().size(),
-                        request.getMenuLikes().size())
+                        imageUrls.size(),
+                        menuLikes.size())
         ));
     }
 
@@ -106,23 +113,31 @@ public class ReviewServiceV2 {
         User user = userRepository.findById(userDetails.getId())
                 .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
 
-        Menu menu = menuRepository.findById(request.getMenuLike().getMenuId())
+        MenuLikeRequest menuLike = request.getMenuLike();
+        if (menuLike == null || menuLike.getMenuId() == null) {
+            throw new BaseException(FAILED_VALIDATION);
+        }
+
+        Menu menu = menuRepository.findById(menuLike.getMenuId())
                 .orElseThrow(() -> new BaseException(NOT_FOUND_MENU));
 
         Review review = request.toReviewEntity(user, menu);
-        review.addReviewMenuLike(menu, request.getMenuLike().getIsLike());
-        request.getImageUrls().forEach(review::addReviewImage);
+        boolean isLike = Boolean.TRUE.equals(menuLike.getIsLike());
+        review.addReviewMenuLike(menu, isLike);
+
+        List<String> imageUrls = Optional.ofNullable(request.getImageUrls()).orElse(Collections.emptyList());
+        imageUrls.forEach(review::addReviewImage);
         reviewRepository.save(review);
 
         menu.addReview(review);
 
         eventPublisher.publishEvent(LogEvent.of(
-                String.format("MenuReview created: reviewId=%d, menuId=%d, userId=%d, isLike=%s, imageUrl=%s",
+                String.format("MenuReview created: reviewId=%d, menuId=%d, userId=%d, isLike=%s, images=%d",
                               review.getId(),
                               menu.getId(),
                               user.getId(),
-                              request.getMenuLike().getIsLike(),
-                              request.getImageUrls().size())
+                              isLike,
+                              imageUrls.size())
         ));
     }
 
@@ -385,12 +400,20 @@ public class ReviewServiceV2 {
             throw new BaseException(REVIEW_PERMISSION_DENIED);
         }
 
-        Map<Menu, Boolean> menuLikes = request.getMenuLikes().stream()
-                                              .collect(Collectors.toMap(
-                                                      menuLike -> menuRepository.findById(menuLike.getMenuId())
-                                                                                .orElseThrow(() -> new BaseException(
-                                                                                        NOT_FOUND_MENU)),
-                                                      MenuLikeRequest::getIsLike));
+        List<MenuLikeRequest> menuLikeRequests = Optional.ofNullable(request.getMenuLikes()).orElse(Collections.emptyList());
+
+        Map<Menu, Boolean> menuLikes = menuLikeRequests.stream()
+                                                       .filter(Objects::nonNull)
+                                                       .collect(Collectors.toMap(
+                                                               menuLike -> {
+                                                                   if (menuLike.getMenuId() == null) {
+                                                                       throw new BaseException(FAILED_VALIDATION);
+                                                                   }
+                                                                   return menuRepository.findById(menuLike.getMenuId())
+                                                                                        .orElseThrow(() -> new BaseException(
+                                                                                                NOT_FOUND_MENU));
+                                                               },
+                                                               menuLike -> Boolean.TRUE.equals(menuLike.getIsLike())));
 
         review.update(request.getContent(), request.getRating(), menuLikes);
         reviewRepository.save(review);


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
resolved #349

> 원인: /v2/reviews/menu에서 CreateMenuReviewRequestV2.menuLike를 필수로 가정하고 request.getMenuLike().getMenuId()를 바로 호출해서, 요청이 menuLike: null로 오면 NPE로 500이 발생했습니다.

좀 더 풀어서 설명하자면, 
 CreateMenuReviewRequestV2의 경우 menuLike(meunid, islike)이외에 별도의 menuid를 받지 않습니다(중복된다 판단하여 별도로 추가하지 않았습니다)
그렇기에 menu에 대한 리뷰를 작성하는데, menuId가 없어서 NPE이 발생했습니다. 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->


>해결:  현재 발생한 500 NPE를 400대 에러로 방어하며, 추가적으로 NPE를 방지하기 위해 다음과 같은 조건을 추가했습니다.
- CreateMenuReviewRequestV2.rating, CreateMenuReviewRequestV2.menuLike에 @NotNull 추가, menuLike에 @Valid 추가
- MenuLikeRequest.menuId에 @NotNull 추가
- ReviewServiceV2.createMenuReview()에서 menuLike/menuId null이면 BaseException(FAILED_VALIDATION)으로 처리
- isLike가 null이어도 NPE 안 나도록 Boolean.TRUE.equals(...)로 기본값 false 처리
- imageUrls/menuLikes가 null이어도 NPE 안 나도록 Collections.emptyList()로 방어(식단리뷰/리뷰수정도 같이 보강)



## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
not null이 과하지 않은지 점검 부탁드립니다.
저의 생각은
- CreateMenuReviewRequestV2.menuLike @NotNull
  이 엔드포인트(/v2/reviews/menu)는 메뉴를 식별할 값이 menuLike.menuId밖에 없어서, menuLike가 null이면 애초에 처리 불가능 (이 PR 핵심입니다)
- MenuLikeRequest.menuId @NotNull
   menuId가 없으면 islike가 true든 false든 메뉴리뷰든 의미가 성립하지 않습니다. (다만 CreateMealReviewRequest.menuLikes는 필드에 @Valid가 없어서 “검증 어노테이션만으로”는 리스트 원소 검증이 안 걸릴 수 있는데, 서비스에서 이미 null 방어를 추가해둔 상태라 동작상 문제는 없습니다.
- CreateMenuReviewRequestV2.rating @NotNull
  현재 기획단에서 0점 리뷰를 금지하고 있습니다. 
  기존에는 @Min/@Max만 있어서 rating:null도 검증을 통과할 수 있었습니다.(Bean Validation은 null이면 통과)
  NotNull을 통해 해당 정책을 명시적으로 400으로 바꿨습니다. 

> 꼭 전체적인 이해 후에 approved 부탁드립니다! 질문/의견 있으면 편하게 남겨주세요

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
