### PR TITLE
feat: 제휴 기간 타입 구분을 위한 periodType 추가

### DIFF
--- a/src/main/java/ssu/eatssu/domain/partnership/dto/PartnershipInfo.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/dto/PartnershipInfo.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import ssu.eatssu.domain.partnership.entity.Partnership;
 import ssu.eatssu.domain.partnership.entity.PartnershipRestaurant;
+import ssu.eatssu.domain.partnership.entity.PeriodType;
 
 import java.time.LocalDate;
 
@@ -18,6 +19,7 @@ public class PartnershipInfo {
     private String description;
     private LocalDate startDate;
     private LocalDate endDate;
+    private PeriodType periodType;
 
     public static PartnershipInfo fromEntity(Partnership partnership,
                                              PartnershipRestaurant restaurant,
@@ -27,6 +29,7 @@ public class PartnershipInfo {
                               .description(partnership.getDescription())
                               .startDate(partnership.getStartDate())
                               .endDate(partnership.getEndDate())
+                              .periodType(partnership.getPeriodType())
                               .collegeName(partnership.getPartnershipCollege() == null && partnership.getPartnershipDepartment() == null
                                                    ? "총학생회"
                                                    : (partnership.getPartnershipCollege() != null ? partnership.getPartnershipCollege()

--- a/src/main/java/ssu/eatssu/domain/partnership/dto/PartnershipResponse.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/dto/PartnershipResponse.java
@@ -38,4 +38,3 @@ public class PartnershipResponse {
                                   .build();
     }
 }
-

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/Partnership.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/Partnership.java
@@ -2,6 +2,8 @@ package ssu.eatssu.domain.partnership.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -39,6 +41,12 @@ public class Partnership {
 
     @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "period_type", nullable = false)
+    private PeriodType periodType = PeriodType.NORMAL;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "partnership_college_id")
     private College partnershipCollege;

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/Partnership.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/Partnership.java
@@ -45,7 +45,7 @@ public class Partnership {
     @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "period_type", nullable = false)
-    private PeriodType periodType = PeriodType.REGULAR;
+    private PeriodType periodType = PeriodType.NORMAL;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "partnership_college_id")

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/Partnership.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/Partnership.java
@@ -45,7 +45,7 @@ public class Partnership {
     @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(name = "period_type", nullable = false)
-    private PeriodType periodType = PeriodType.NORMAL;
+    private PeriodType periodType = PeriodType.REGULAR;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "partnership_college_id")

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/PeriodType.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/PeriodType.java
@@ -1,6 +1,6 @@
 package ssu.eatssu.domain.partnership.entity;
 
 public enum PeriodType {
-    NORMAL,
+    REGULAR,
     FESTIVAL
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/PeriodType.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/PeriodType.java
@@ -1,6 +1,6 @@
 package ssu.eatssu.domain.partnership.entity;
 
 public enum PeriodType {
-    REGULAR,
+    NORMAL,
     FESTIVAL
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/PeriodType.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/PeriodType.java
@@ -1,0 +1,6 @@
+package ssu.eatssu.domain.partnership.entity;
+
+public enum PeriodType {
+    NORMAL,
+    FESTIVAL
+}

--- a/src/main/resources/db/migration/V5__add_period_type_to_partnership.sql
+++ b/src/main/resources/db/migration/V5__add_period_type_to_partnership.sql
@@ -1,0 +1,6 @@
+-- =========================
+-- V5: partnership 기간 타입 추가
+-- =========================
+
+ALTER TABLE partnership
+    ADD COLUMN period_type ENUM ('NORMAL', 'FESTIVAL') NOT NULL DEFAULT 'NORMAL';


### PR DESCRIPTION
## #️⃣ Issue Number

- resolved #354 

## 📝 요약(Summary)

- `partnership` 테이블에 제휴 기간 타입을 구분하는 `period_type` 컬럼을 추가했습니다.
- Flyway migration을 추가하여 배포 시 DB 스키마가 자동으로 반영되도록 했습니다.
- `Partnership` 엔티티에 `PeriodType` enum 매핑을 추가했습니다.
- 제휴 건별 응답인 `PartnershipInfo`에 `periodType`을 포함하도록 수정했습니다.

## 💬 공유사항 to 리뷰어

- `periodType`은 식당 단위가 아니라 제휴 정보 단위의 속성으로 판단해 `PartnershipResponse`가 아닌 `PartnershipInfo`에 포함했습니다.
- DB enum 값과 Java enum 값을 `REGULAR`, `FESTIVAL`로 맞췄습니다.
- 기존 데이터는 migration의 `DEFAULT 'REGULAR'`로 채워집니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
<img width="1409" height="509" alt="image" src="https://github.com/user-attachments/assets/b83f4ba5-5c6f-4b70-bf84-7c0fb9741fc9" />
