### PR TITLE
feat: 다국어 지원 기능 추가

### DIFF
--- a/src/main/java/ssu/eatssu/domain/partnership/dto/PartnershipResponse.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/dto/PartnershipResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import ssu.eatssu.domain.partnership.entity.PartnershipRestaurant;
 import ssu.eatssu.domain.partnership.entity.RestaurantType;
+import ssu.eatssu.domain.user.entity.Language;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,7 +20,7 @@ public class PartnershipResponse {
     private RestaurantType restaurantType;
     private List<PartnershipInfo> partnershipInfos;
 
-    public static PartnershipResponse fromEntity(PartnershipRestaurant restaurant, Long userId) {
+    public static PartnershipResponse fromEntity(PartnershipRestaurant restaurant, Long userId, Language language) {
         boolean isLiked = restaurant.getLikes().stream()
                                     .anyMatch(like -> like.getUser().getId().equals(userId));
 
@@ -30,7 +31,7 @@ public class PartnershipResponse {
                                                 .collect(Collectors.toList());
 
         return PartnershipResponse.builder()
-                                  .storeName(restaurant.getStoreName())
+                                  .storeName(restaurant.getStoreNameByLanguage(language))
                                   .longitude(restaurant.getLongitude())
                                   .latitude(restaurant.getLatitude())
                                   .restaurantType(restaurant.getRestaurantType())

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/PartnershipRestaurant.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/PartnershipRestaurant.java
@@ -13,6 +13,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
+import ssu.eatssu.domain.user.entity.Language;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,5 +52,18 @@ public class PartnershipRestaurant {
 
     public String getStoreName() {
         return storeNameKo;
+    }
+
+    public String getStoreNameByLanguage(Language language) {
+        if (language == null) {
+            return storeNameKo;
+        }
+
+        return switch (language) {
+            case EN -> storeNameEn != null ? storeNameEn : storeNameKo;
+            case JA -> storeNameJa != null ? storeNameJa : storeNameKo;
+            case VI -> storeNameVi != null ? storeNameVi : storeNameKo;
+            case KO -> storeNameKo;
+        };
     }
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/PartnershipRestaurant.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/PartnershipRestaurant.java
@@ -34,12 +34,22 @@ public class PartnershipRestaurant {
 
     @Column(name = "latitude", nullable = false)
     private Double latitude; // 위도 == y축
-    @Column(name = "store_name", nullable = false)
-    private String storeName;
+    @Column(name = "store_name_ko", nullable = false)
+    private String storeNameKo;
+    @Column(name = "store_name_en")
+    private String storeNameEn;
+    @Column(name = "store_name_ja")
+    private String storeNameJa;
+    @Column(name = "store_name_vi")
+    private String storeNameVi;
 
     @OneToMany(mappedBy = "partnershipRestaurant")
     @BatchSize(size = 20)
     private List<PartnershipLike> likes = new ArrayList<>();
     @OneToMany(mappedBy = "partnershipRestaurant", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Partnership> partnerships = new ArrayList<>();
+
+    public String getStoreName() {
+        return storeNameKo;
+    }
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/PartnershipRestaurant.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/PartnershipRestaurant.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
 import ssu.eatssu.domain.user.entity.Language;
+import ssu.eatssu.global.i18n.Localizable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,7 +22,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PartnershipRestaurant {
+public class PartnershipRestaurant implements Localizable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "partnershipRestaurant_id")
@@ -55,15 +56,6 @@ public class PartnershipRestaurant {
     }
 
     public String getStoreNameByLanguage(Language language) {
-        if (language == null) {
-            return storeNameKo;
-        }
-
-        return switch (language) {
-            case EN -> storeNameEn != null ? storeNameEn : storeNameKo;
-            case JA -> storeNameJa != null ? storeNameJa : storeNameKo;
-            case VI -> storeNameVi != null ? storeNameVi : storeNameKo;
-            case KO -> storeNameKo;
-        };
+        return getLocalizedValue(language, storeNameKo, storeNameEn, storeNameJa, storeNameVi);
     }
 }

--- a/src/main/java/ssu/eatssu/domain/partnership/service/PartnershipService.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/service/PartnershipService.java
@@ -52,7 +52,7 @@ public class PartnershipService {
                                                                                              NOT_FOUND_PARTNERSHIP_RESTAURANT));
         Partnership partnership = request.toPartnershipEntity(partnershipRestaurant);
 
-        College college = collegeRepository.findByName(request.getCollege())
+        College college = collegeRepository.findByNameKo(request.getCollege())
                                            .orElseThrow(() -> new BaseException(NOT_FOUND_COLLEGE));
         partnership.setPartnershipCollege(college);
         Department department = departmentRepository.findByName(request.getDepartment())

--- a/src/main/java/ssu/eatssu/domain/partnership/service/PartnershipService.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/service/PartnershipService.java
@@ -55,7 +55,7 @@ public class PartnershipService {
         College college = collegeRepository.findByNameKo(request.getCollege())
                                            .orElseThrow(() -> new BaseException(NOT_FOUND_COLLEGE));
         partnership.setPartnershipCollege(college);
-        Department department = departmentRepository.findByName(request.getDepartment())
+        Department department = departmentRepository.findByNameKo(request.getDepartment())
                                                     .orElseThrow(() -> new BaseException(NOT_FOUND_DEPARTMENT));
         partnership.setPartnershipDepartment(department);
         partnershipRepository.save(partnership);

--- a/src/main/java/ssu/eatssu/domain/partnership/service/PartnershipService.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/service/PartnershipService.java
@@ -18,6 +18,7 @@ import ssu.eatssu.domain.user.department.entity.College;
 import ssu.eatssu.domain.user.department.entity.Department;
 import ssu.eatssu.domain.user.department.persistence.CollegeRepository;
 import ssu.eatssu.domain.user.department.persistence.DepartmentRepository;
+import ssu.eatssu.domain.user.entity.Language;
 import ssu.eatssu.domain.user.entity.User;
 import ssu.eatssu.domain.user.repository.UserRepository;
 import ssu.eatssu.global.handler.response.BaseException;
@@ -62,9 +63,12 @@ public class PartnershipService {
     }
 
     public List<PartnershipResponse> getAllPartnerships(CustomUserDetails customUserDetails) {
+        Language language = findUserByUserDetails(customUserDetails).getLanguage();
+
         return partnerShipRestaurantRepository.findAllWithDetails().stream()
                                               .map(restaurant -> PartnershipResponse.fromEntity(restaurant,
-                                                                                                customUserDetails.getId()))
+                                                                                                customUserDetails.getId(),
+                                                                                                language))
                                               .collect(Collectors.toList());
     }
 
@@ -100,8 +104,7 @@ public class PartnershipService {
     }
 
     public List<PartnershipResponse> getUserLikedPartnerships(CustomUserDetails customUserDetails) {
-        User user = userRepository.findById(customUserDetails.getId())
-                                  .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+        User user = findUserByUserDetails(customUserDetails);
 
         List<PartnershipLike> likes = partnershipLikeRepository.findAllByUserWithDetails(user);
 
@@ -111,14 +114,14 @@ public class PartnershipService {
                         return restaurant.getPartnerships()
                                          .stream()
                                          .map(partnership -> PartnershipResponse.fromEntity(restaurant,
-                                                                                            customUserDetails.getId()));
+                                                                                            customUserDetails.getId(),
+                                                                                            user.getLanguage()));
                     }).collect(Collectors.toList());
     }
 
 
     public List<PartnershipResponse> getUserDepartmentPartnerships(CustomUserDetails customUserDetails) {
-        User user = userRepository.findById(customUserDetails.getId())
-                                  .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+        User user = findUserByUserDetails(customUserDetails);
 
         Department department = user.getDepartment();
         if (department == null) {
@@ -130,7 +133,13 @@ public class PartnershipService {
                 .findRestaurantsWithMyPartnerships(college, department)
                 .stream()
                 .map(partnershipRestaurant -> PartnershipResponse.fromEntity(partnershipRestaurant,
-                                                                             customUserDetails.getId()))
+                                                                             customUserDetails.getId(),
+                                                                             user.getLanguage()))
                 .collect(Collectors.toList());
+    }
+
+    private User findUserByUserDetails(CustomUserDetails userDetails) {
+        return userRepository.findById(userDetails.getId())
+                             .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/department/entity/College.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/entity/College.java
@@ -27,10 +27,20 @@ public class College {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "college_id")
     private Long id;
-    @Column(nullable = false, unique = true)
-    private String name;
+    @Column(name = "name_ko", nullable = false, unique = true)
+    private String nameKo;
+    @Column(name = "name_en")
+    private String nameEn;
+    @Column(name = "name_ja")
+    private String nameJa;
+    @Column(name = "name_vi")
+    private String nameVi;
 
     public College(String name) {
-        this.name = name;
+        this.nameKo = name;
+    }
+
+    public String getName() {
+        return nameKo;
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/department/entity/College.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/entity/College.java
@@ -11,6 +11,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ssu.eatssu.domain.partnership.entity.Partnership;
+import ssu.eatssu.domain.user.entity.Language;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,5 +43,18 @@ public class College {
 
     public String getName() {
         return nameKo;
+    }
+
+    public String getNameByLanguage(Language language) {
+        if (language == null) {
+            return nameKo;
+        }
+
+        return switch (language) {
+            case EN -> nameEn != null ? nameEn : nameKo;
+            case JA -> nameJa != null ? nameJa : nameKo;
+            case VI -> nameVi != null ? nameVi : nameKo;
+            case KO -> nameKo;
+        };
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/department/entity/College.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/entity/College.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ssu.eatssu.domain.partnership.entity.Partnership;
 import ssu.eatssu.domain.user.entity.Language;
+import ssu.eatssu.global.i18n.Localizable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +20,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class College {
+public class College implements Localizable {
     @OneToMany(mappedBy = "college", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Department> departments = new ArrayList<>();
     @OneToMany(mappedBy = "partnershipCollege", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -46,15 +47,6 @@ public class College {
     }
 
     public String getNameByLanguage(Language language) {
-        if (language == null) {
-            return nameKo;
-        }
-
-        return switch (language) {
-            case EN -> nameEn != null ? nameEn : nameKo;
-            case JA -> nameJa != null ? nameJa : nameKo;
-            case VI -> nameVi != null ? nameVi : nameKo;
-            case KO -> nameKo;
-        };
+        return getLocalizedValue(language, nameKo, nameEn, nameJa, nameVi);
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/department/entity/Department.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/entity/Department.java
@@ -14,6 +14,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ssu.eatssu.domain.partnership.entity.Partnership;
+import ssu.eatssu.domain.user.entity.Language;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,5 +47,18 @@ public class Department {
 
     public String getName() {
         return nameKo;
+    }
+
+    public String getNameByLanguage(Language language) {
+        if (language == null) {
+            return nameKo;
+        }
+
+        return switch (language) {
+            case EN -> nameEn != null ? nameEn : nameKo;
+            case JA -> nameJa != null ? nameJa : nameKo;
+            case VI -> nameVi != null ? nameVi : nameKo;
+            case KO -> nameKo;
+        };
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/department/entity/Department.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/entity/Department.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ssu.eatssu.domain.partnership.entity.Partnership;
 import ssu.eatssu.domain.user.entity.Language;
+import ssu.eatssu.global.i18n.Localizable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +23,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Department {
+public class Department implements Localizable {
     @OneToMany(mappedBy = "partnershipDepartment", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Partnership> partnerships = new ArrayList<>();
     @Id
@@ -50,15 +51,6 @@ public class Department {
     }
 
     public String getNameByLanguage(Language language) {
-        if (language == null) {
-            return nameKo;
-        }
-
-        return switch (language) {
-            case EN -> nameEn != null ? nameEn : nameKo;
-            case JA -> nameJa != null ? nameJa : nameKo;
-            case VI -> nameVi != null ? nameVi : nameKo;
-            case KO -> nameKo;
-        };
+        return getLocalizedValue(language, nameKo, nameEn, nameJa, nameVi);
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/department/entity/Department.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/entity/Department.java
@@ -28,13 +28,23 @@ public class Department {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "department_id")
     private Long id;
-    @Column(nullable = false)
-    private String name;
+    @Column(name = "name_ko", nullable = false)
+    private String nameKo;
+    @Column(name = "name_en")
+    private String nameEn;
+    @Column(name = "name_ja")
+    private String nameJa;
+    @Column(name = "name_vi")
+    private String nameVi;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "college_id")
     private College college;
 
     public Department(String name) {
-        this.name = name;
+        this.nameKo = name;
+    }
+
+    public String getName() {
+        return nameKo;
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/department/persistence/CollegeRepository.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/persistence/CollegeRepository.java
@@ -6,5 +6,5 @@ import ssu.eatssu.domain.user.department.entity.College;
 import java.util.Optional;
 
 public interface CollegeRepository extends JpaRepository<College, Long> {
-    Optional<College> findByName(String name);
+    Optional<College> findByNameKo(String nameKo);
 }

--- a/src/main/java/ssu/eatssu/domain/user/department/persistence/DepartmentRepository.java
+++ b/src/main/java/ssu/eatssu/domain/user/department/persistence/DepartmentRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
-    Optional<Department> findByName(String name);
+    Optional<Department> findByNameKo(String nameKo);
 
     List<Department> findByCollege(College college);
 }

--- a/src/main/java/ssu/eatssu/domain/user/dto/DepartmentResponse.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/DepartmentResponse.java
@@ -3,22 +3,26 @@ package ssu.eatssu.domain.user.dto;
 import lombok.Builder;
 import ssu.eatssu.domain.user.department.entity.College;
 import ssu.eatssu.domain.user.department.entity.Department;
+import ssu.eatssu.domain.user.entity.Language;
 
 @Builder
 public record DepartmentResponse(
         Long departmentId, String departmentName, Long collegeId, String collegeName
 ) {
     public static DepartmentResponse from(Department department) {
+        return from(department, Language.KO);
+    }
+
+    public static DepartmentResponse from(Department department, Language language) {
         if (department == null) {
             return new DepartmentResponse(null, null, null, null);
         }
         final College college = department.getCollege();
         return DepartmentResponse.builder()
                                  .departmentId(department.getId())
-                                 .departmentName(department.getName())
+                                 .departmentName(department.getNameByLanguage(language))
                                  .collegeId(college != null ? college.getId() : null)
-                                 .collegeName(college != null ? college.getName() : null)
+                                 .collegeName(college != null ? college.getNameByLanguage(language) : null)
                                  .build();
     }
 }
-

--- a/src/main/java/ssu/eatssu/domain/user/dto/LanguageResponse.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/LanguageResponse.java
@@ -1,0 +1,15 @@
+package ssu.eatssu.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import ssu.eatssu.domain.user.entity.Language;
+import ssu.eatssu.domain.user.entity.User;
+
+@Schema(title = "언어 설정 조회")
+public record LanguageResponse(
+        @Schema(description = "언어 설정", example = "KO")
+        Language language) {
+
+    public static LanguageResponse from(User user) {
+        return new LanguageResponse(user.getLanguage());
+    }
+}

--- a/src/main/java/ssu/eatssu/domain/user/dto/LanguageUpdateRequest.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/LanguageUpdateRequest.java
@@ -1,0 +1,12 @@
+package ssu.eatssu.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import ssu.eatssu.domain.user.entity.Language;
+
+@Schema(title = "언어 설정 수정")
+public record LanguageUpdateRequest(
+        @NotNull(message = "언어 설정을 입력해주세요.")
+        @Schema(description = "언어 설정", example = "EN", allowableValues = {"KO", "EN", "JA", "VI"})
+        Language language) {
+}

--- a/src/main/java/ssu/eatssu/domain/user/dto/MyPageResponse.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/MyPageResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import ssu.eatssu.domain.auth.entity.OAuthProvider;
 import ssu.eatssu.domain.user.department.entity.College;
 import ssu.eatssu.domain.user.department.entity.Department;
+import ssu.eatssu.domain.user.entity.Language;
 import ssu.eatssu.domain.user.entity.User;
 
 @AllArgsConstructor
@@ -20,6 +21,9 @@ public class MyPageResponse {
 
     @Schema(description = "연결 계정 정보", example = "GOOGLE")
     private OAuthProvider provider;
+
+    @Schema(description = "언어 설정", example = "KO")
+    private Language language;
 
     @Schema(description = "학과 id", example = "1")
     private Long departmentId;
@@ -44,6 +48,7 @@ public class MyPageResponse {
         return MyPageResponse.builder()
                              .nickname(user.getNickname())
                              .provider(user.getProvider())
+                             .language(user.getLanguage())
                              .departmentId(department != null ? department.getId() : null)
                              .departmentName(department != null ? department.getName() : null)
                              .collegeId(college != null ? college.getId() : null)

--- a/src/main/java/ssu/eatssu/domain/user/dto/MyPageResponse.java
+++ b/src/main/java/ssu/eatssu/domain/user/dto/MyPageResponse.java
@@ -50,9 +50,9 @@ public class MyPageResponse {
                              .provider(user.getProvider())
                              .language(user.getLanguage())
                              .departmentId(department != null ? department.getId() : null)
-                             .departmentName(department != null ? department.getName() : null)
+                             .departmentName(department != null ? department.getNameByLanguage(user.getLanguage()) : null)
                              .collegeId(college != null ? college.getId() : null)
-                             .collegeName(college != null ? college.getName() : null)
+                             .collegeName(college != null ? college.getNameByLanguage(user.getLanguage()) : null)
                              .build();
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/entity/Language.java
+++ b/src/main/java/ssu/eatssu/domain/user/entity/Language.java
@@ -1,0 +1,8 @@
+package ssu.eatssu.domain.user.entity;
+
+public enum Language {
+    KO,
+    EN,
+    JA,
+    VI
+}

--- a/src/main/java/ssu/eatssu/domain/user/entity/User.java
+++ b/src/main/java/ssu/eatssu/domain/user/entity/User.java
@@ -79,7 +79,6 @@ public class User extends BaseTimeEntity {
         this.status = status;
         this.credentials = credentials;
         this.deviceType = deviceType;
-        this.language = Language.KO;
     }
 
     // TODO : 회원 가입 V2 마이그레이션 이후 삭제.

--- a/src/main/java/ssu/eatssu/domain/user/entity/User.java
+++ b/src/main/java/ssu/eatssu/domain/user/entity/User.java
@@ -59,6 +59,9 @@ public class User extends BaseTimeEntity {
     private UserStatus status;
     @Enumerated(EnumType.STRING)
     private DeviceType deviceType;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Language language = Language.KO;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "department_id")
     private Department department;
@@ -76,6 +79,7 @@ public class User extends BaseTimeEntity {
         this.status = status;
         this.credentials = credentials;
         this.deviceType = deviceType;
+        this.language = Language.KO;
     }
 
     // TODO : 회원 가입 V2 마이그레이션 이후 삭제.

--- a/src/main/java/ssu/eatssu/domain/user/entity/User.java
+++ b/src/main/java/ssu/eatssu/domain/user/entity/User.java
@@ -127,6 +127,10 @@ public class User extends BaseTimeEntity {
         this.department = department;
     }
 
+    public void updateLanguage(@NotNull Language language) {
+        this.language = language;
+    }
+
     // 추후에 기종이 바뀌더라도 업데이트합니다. + V1-> V2 마이그레이션을 수행하는 역할을 하기도 합니다.
     public void updateDeviceType(DeviceType deviceType) { this.deviceType = deviceType; }
 }

--- a/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
+++ b/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
@@ -33,6 +33,7 @@ import ssu.eatssu.domain.slice.service.SliceService;
 import ssu.eatssu.domain.user.dto.DepartmentResponse;
 import ssu.eatssu.domain.user.dto.GetCollegeResponse;
 import ssu.eatssu.domain.user.dto.GetDepartmentResponse;
+import ssu.eatssu.domain.user.dto.LanguageResponse;
 import ssu.eatssu.domain.user.dto.LanguageUpdateRequest;
 import ssu.eatssu.domain.user.dto.MyMealReviewResponse;
 import ssu.eatssu.domain.user.dto.MyPageResponse;
@@ -127,6 +128,17 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.updateLanguage(userDetails, request);
         return BaseResponse.success();
+    }
+
+    @Operation(summary = "언어 설정 조회", description = "유저의 언어 설정을 조회하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "언어 설정 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    @GetMapping("/language")
+    public BaseResponse<LanguageResponse> getLanguage(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return BaseResponse.success(userService.findLanguage(userDetails));
     }
 
     @Operation(summary = "유저 탈퇴", description = "유저 탈퇴 API 입니다.")

--- a/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
+++ b/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
@@ -33,6 +33,7 @@ import ssu.eatssu.domain.slice.service.SliceService;
 import ssu.eatssu.domain.user.dto.DepartmentResponse;
 import ssu.eatssu.domain.user.dto.GetCollegeResponse;
 import ssu.eatssu.domain.user.dto.GetDepartmentResponse;
+import ssu.eatssu.domain.user.dto.LanguageUpdateRequest;
 import ssu.eatssu.domain.user.dto.MyMealReviewResponse;
 import ssu.eatssu.domain.user.dto.MyPageResponse;
 import ssu.eatssu.domain.user.dto.MyReviewDetail;
@@ -111,6 +112,20 @@ public class UserController {
             @Valid @RequestBody NicknameUpdateRequest updateNicknameRequest,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.updateNickname(userDetails, updateNicknameRequest);
+        return BaseResponse.success();
+    }
+
+    @Operation(summary = "언어 설정 수정", description = "유저의 언어 설정을 수정하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "언어 설정 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "지원하지 않는 언어 또는 누락된 언어 설정", content = @Content(schema = @Schema(implementation = BaseResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
+    })
+    @PatchMapping("/language")
+    public BaseResponse<?> updateLanguage(
+            @Valid @RequestBody LanguageUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.updateLanguage(userDetails, request);
         return BaseResponse.success();
     }
 

--- a/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
+++ b/src/main/java/ssu/eatssu/domain/user/presentation/UserController.java
@@ -244,8 +244,9 @@ public class UserController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 단과대", content = @Content(schema = @Schema(implementation = BaseResponse.class)))
     })
     @GetMapping("/lookup/colleges")
-    public BaseResponse<List<GetCollegeResponse>> getColleges() {
-        List<GetCollegeResponse> getCollegeResponses = userService.getCollegeList();
+    public BaseResponse<List<GetCollegeResponse>> getColleges(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<GetCollegeResponse> getCollegeResponses = userService.getCollegeList(userDetails);
         return BaseResponse.success(getCollegeResponses);
     }
 
@@ -254,8 +255,9 @@ public class UserController {
             @ApiResponse(responseCode = "200", description = "단과대 리스트 조회 성공"),
     })
     @GetMapping("/lookup/departments")
-    public BaseResponse<List<GetDepartmentResponse>> getDepartments(@RequestParam Long collegeId) {
-        List<GetDepartmentResponse> getCollegeResponses = userService.getDepartmentList(collegeId);
+    public BaseResponse<List<GetDepartmentResponse>> getDepartments(@RequestParam Long collegeId,
+                                                                    @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<GetDepartmentResponse> getCollegeResponses = userService.getDepartmentList(collegeId, userDetails);
         return BaseResponse.success(getCollegeResponses);
     }
 

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -18,6 +18,7 @@ import ssu.eatssu.domain.user.department.persistence.DepartmentRepository;
 import ssu.eatssu.domain.user.dto.DepartmentResponse;
 import ssu.eatssu.domain.user.dto.GetCollegeResponse;
 import ssu.eatssu.domain.user.dto.GetDepartmentResponse;
+import ssu.eatssu.domain.user.dto.LanguageResponse;
 import ssu.eatssu.domain.user.dto.LanguageUpdateRequest;
 import ssu.eatssu.domain.user.dto.MyPageResponse;
 import ssu.eatssu.domain.user.dto.NicknameUpdateRequest;
@@ -98,6 +99,11 @@ public class UserService {
                 String.format("User language updated: userId=%d, language=%s",
                         user.getId(), request.language()))
         );
+    }
+
+    public LanguageResponse findLanguage(CustomUserDetails userDetails) {
+        User user = findUserByUserDetails(userDetails);
+        return LanguageResponse.from(user);
     }
 
     public boolean withdraw(CustomUserDetails userDetails) {

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -1,11 +1,10 @@
 package ssu.eatssu.domain.user.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import ssu.eatssu.domain.auth.entity.OAuthProvider;
 import ssu.eatssu.domain.auth.security.CustomUserDetails;
@@ -42,7 +41,6 @@ import static ssu.eatssu.global.handler.response.BaseResponseStatus.VALIDATION_E
 @Service
 @RequiredArgsConstructor
 @Transactional
-@Component
 public class UserService {
 
     private final UserRepository userRepository;

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -23,6 +23,7 @@ import ssu.eatssu.domain.user.dto.MyPageResponse;
 import ssu.eatssu.domain.user.dto.NicknameUpdateRequest;
 import ssu.eatssu.domain.user.dto.UpdateDepartmentRequest;
 import ssu.eatssu.domain.user.entity.DeviceType;
+import ssu.eatssu.domain.user.entity.Language;
 import ssu.eatssu.domain.user.entity.User;
 import ssu.eatssu.domain.user.repository.UserRepository;
 import ssu.eatssu.domain.user.util.NicknameValidator;
@@ -140,7 +141,7 @@ public class UserService {
 
     public DepartmentResponse getDepartment(CustomUserDetails userDetails) {
         User user = findUserByUserDetails(userDetails);
-        return DepartmentResponse.from(user.getDepartment());
+        return DepartmentResponse.from(user.getDepartment(), user.getLanguage());
     }
 
     private User findUserByUserDetails(CustomUserDetails userDetails) {
@@ -148,23 +149,32 @@ public class UserService {
                              .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
     }
 
-    public List<GetCollegeResponse> getCollegeList() {
+    public List<GetCollegeResponse> getCollegeList(CustomUserDetails userDetails) {
+        Language language = findLanguageOrDefault(userDetails);
         List<College> colleges = collegeRepository.findAll();
         return colleges.stream().map(college -> GetCollegeResponse.builder()
                                                                   .id(college.getId())
-                                                                  .name(college.getName())
+                                                                  .name(college.getNameByLanguage(language))
                                                                   .build())
                        .toList();
     }
 
-    public List<GetDepartmentResponse> getDepartmentList(Long collegeId) {
+    public List<GetDepartmentResponse> getDepartmentList(Long collegeId, CustomUserDetails userDetails) {
+        Language language = findLanguageOrDefault(userDetails);
         College college = collegeRepository.findById(collegeId)
                                            .orElseThrow(() -> new BaseException(VALIDATION_ERROR));
         List<Department> departments = departmentRepository.findByCollege(college);
         return departments.stream().map(department -> GetDepartmentResponse.builder()
                                                                            .id(department.getId())
-                                                                           .name(department.getName())
+                                                                           .name(department.getNameByLanguage(language))
                                                                            .build())
                           .toList();
+    }
+
+    private Language findLanguageOrDefault(CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            return Language.KO;
+        }
+        return findUserByUserDetails(userDetails).getLanguage();
     }
 }

--- a/src/main/java/ssu/eatssu/domain/user/service/UserService.java
+++ b/src/main/java/ssu/eatssu/domain/user/service/UserService.java
@@ -18,6 +18,7 @@ import ssu.eatssu.domain.user.department.persistence.DepartmentRepository;
 import ssu.eatssu.domain.user.dto.DepartmentResponse;
 import ssu.eatssu.domain.user.dto.GetCollegeResponse;
 import ssu.eatssu.domain.user.dto.GetDepartmentResponse;
+import ssu.eatssu.domain.user.dto.LanguageUpdateRequest;
 import ssu.eatssu.domain.user.dto.MyPageResponse;
 import ssu.eatssu.domain.user.dto.NicknameUpdateRequest;
 import ssu.eatssu.domain.user.dto.UpdateDepartmentRequest;
@@ -65,8 +66,7 @@ public class UserService {
     }
 
     public void updateNickname(CustomUserDetails userDetails, NicknameUpdateRequest request) {
-        User user = userRepository.findById(userDetails.getId())
-                                  .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+        User user = findUserByUserDetails(userDetails);
 
         nicknameValidator.validateNickname(request.nickname());
 
@@ -84,14 +84,23 @@ public class UserService {
     }
 
     public MyPageResponse findMyPage(CustomUserDetails userDetails) {
-        User user = userRepository.findById(userDetails.getId())
-                                  .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+        User user = findUserByUserDetails(userDetails);
         return MyPageResponse.from(user);
     }
 
+    public void updateLanguage(CustomUserDetails userDetails, LanguageUpdateRequest request) {
+        User user = findUserByUserDetails(userDetails);
+
+        user.updateLanguage(request.language());
+
+        eventPublisher.publishEvent(LogEvent.of(
+                String.format("User language updated: userId=%d, language=%s",
+                        user.getId(), request.language()))
+        );
+    }
+
     public boolean withdraw(CustomUserDetails userDetails) {
-        User user = userRepository.findById(userDetails.getId())
-                                  .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+        User user = findUserByUserDetails(userDetails);
 
         user.getReviews().forEach(Review::clearUser);
         user.getUserInquiries().forEach(inquiry -> inquiry.clearUser());
@@ -122,8 +131,7 @@ public class UserService {
 
     @Transactional
     public void registerDepartment(UpdateDepartmentRequest request, CustomUserDetails userDetails) {
-        User user = userRepository.findById(userDetails.getId())
-                                  .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+        User user = findUserByUserDetails(userDetails);
         Department department = departmentRepository.findById(request.getDepartmentId())
                                                     .orElseThrow(() -> new BaseException(NOT_FOUND_DEPARTMENT));
 
@@ -131,9 +139,13 @@ public class UserService {
     }
 
     public DepartmentResponse getDepartment(CustomUserDetails userDetails) {
-        User user = userRepository.findById(userDetails.getId())
-                                  .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
+        User user = findUserByUserDetails(userDetails);
         return DepartmentResponse.from(user.getDepartment());
+    }
+
+    private User findUserByUserDetails(CustomUserDetails userDetails) {
+        return userRepository.findById(userDetails.getId())
+                             .orElseThrow(() -> new BaseException(NOT_FOUND_USER));
     }
 
     public List<GetCollegeResponse> getCollegeList() {

--- a/src/main/java/ssu/eatssu/global/i18n/Localizable.java
+++ b/src/main/java/ssu/eatssu/global/i18n/Localizable.java
@@ -1,0 +1,19 @@
+package ssu.eatssu.global.i18n;
+
+import ssu.eatssu.domain.user.entity.Language;
+
+public interface Localizable {
+
+    default String getLocalizedValue(Language language, String ko, String en, String ja, String vi) {
+        if (language == null) {
+            return ko;
+        }
+
+        return switch (language) {
+            case EN -> en != null ? en : ko;
+            case JA -> ja != null ? ja : ko;
+            case VI -> vi != null ? vi : ko;
+            case KO -> ko;
+        };
+    }
+}

--- a/src/main/resources/db/migration/V6__add_language_to_user.sql
+++ b/src/main/resources/db/migration/V6__add_language_to_user.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user
+    ADD COLUMN language ENUM ('KO', 'EN', 'JA', 'VI') NOT NULL DEFAULT 'KO';

--- a/src/main/resources/db/migration/V7__add_i18n_columns_to_college.sql
+++ b/src/main/resources/db/migration/V7__add_i18n_columns_to_college.sql
@@ -1,0 +1,5 @@
+ALTER TABLE college
+    RENAME COLUMN name TO name_ko,
+    ADD COLUMN name_en VARCHAR(255) NULL,
+    ADD COLUMN name_ja VARCHAR(255) NULL,
+    ADD COLUMN name_vi VARCHAR(255) NULL;

--- a/src/main/resources/db/migration/V8__add_i18n_columns_to_department.sql
+++ b/src/main/resources/db/migration/V8__add_i18n_columns_to_department.sql
@@ -1,0 +1,5 @@
+ALTER TABLE department
+    RENAME COLUMN name TO name_ko,
+    ADD COLUMN name_en VARCHAR(255) NULL,
+    ADD COLUMN name_ja VARCHAR(255) NULL,
+    ADD COLUMN name_vi VARCHAR(255) NULL;

--- a/src/main/resources/db/migration/V9__add_i18n_columns_to_partnership_restaurant.sql
+++ b/src/main/resources/db/migration/V9__add_i18n_columns_to_partnership_restaurant.sql
@@ -1,0 +1,5 @@
+ALTER TABLE partnership_restaurant
+    RENAME COLUMN store_name TO store_name_ko,
+    ADD COLUMN store_name_en VARCHAR(255) NULL,
+    ADD COLUMN store_name_ja VARCHAR(255) NULL,
+    ADD COLUMN store_name_vi VARCHAR(255) NULL;

--- a/src/test/java/ssu/eatssu/domain/user/dto/MyPageResponseTest.java
+++ b/src/test/java/ssu/eatssu/domain/user/dto/MyPageResponseTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MyPageResponseTest {
 
     @Test
-    void 사용자_언어에_맞는_학과와_단과대_이름을_반환한다() {
+    void shouldReturnLocalizedNamesBasedOnUserLanguage() {
         // given
         College college = new College("IT 대학");
         ReflectionTestUtils.setField(college, "nameEn", "College of IT");

--- a/src/test/java/ssu/eatssu/domain/user/dto/MyPageResponseTest.java
+++ b/src/test/java/ssu/eatssu/domain/user/dto/MyPageResponseTest.java
@@ -1,0 +1,37 @@
+package ssu.eatssu.domain.user.dto;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import ssu.eatssu.domain.auth.entity.OAuthProvider;
+import ssu.eatssu.domain.user.department.entity.College;
+import ssu.eatssu.domain.user.department.entity.Department;
+import ssu.eatssu.domain.user.entity.Language;
+import ssu.eatssu.domain.user.entity.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MyPageResponseTest {
+
+    @Test
+    void 사용자_언어에_맞는_학과와_단과대_이름을_반환한다() {
+        // given
+        College college = new College("IT 대학");
+        ReflectionTestUtils.setField(college, "nameEn", "College of IT");
+
+        Department department = new Department("컴퓨터학부");
+        ReflectionTestUtils.setField(department, "nameEn", "School of Computer Science");
+        ReflectionTestUtils.setField(department, "college", college);
+
+        User user = User.create("test@test.com", "tester", OAuthProvider.EATSSU, "1234", "credentials");
+        user.updateLanguage(Language.EN);
+        user.updateDepartment(department);
+
+        // when
+        MyPageResponse response = MyPageResponse.from(user);
+
+        // then
+        assertThat(response.getLanguage()).isEqualTo(Language.EN);
+        assertThat(response.getDepartmentName()).isEqualTo("School of Computer Science");
+        assertThat(response.getCollegeName()).isEqualTo("College of IT");
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

  - resolved #357

  ## 📝 요약(Summary)

  사용자 언어 설정 기반의 다국어 응답을 지원하도록 i18n 관련 기능을 추가

  - 사용자 언어 설정(`KO`, `EN`, `JA`, `VI`)을 저장할 수 있도록 `Language` enum과  `user.language` 컬럼을 추가
  - 언어 설정 조회/수정 API를 추가
    - `GET /users/language`
    - `PATCH /users/language`
  - 마이페이지, 학과 조회, 단과대 조회 응답에서 사용자 언어에 맞는 이름을 반환하도록 수정
  - `college`, `department`, `partnership_restaurant`의 기존 이름 컬럼을 한국어 컬럼으로 변경하고, 영어/일본어/베트남어 이름 컬럼을 추가
  - 제휴 매장명도 사용자 언어 설정에 따라 반환되도록 수정
  - 마이페이지 응답이 사용자 언어에 맞는 학과/단과대명을 반환하는지 테스트를 추가

  ## 💬 공유사항 to 리뷰어

 - 다국어 이름은 요청한 언어의 번역값이 없으면 한국어 값으로 fallback되도록 처리
 - `UserService`는 클래스 레벨에 `@Transactional` import 호출 경로가 잘못 적용되어 있어 올바르게 수정

  ## ✅ PR Checklist

  PR이 다음 요구 사항을 충족하는지 확인하세요.

  - [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
  - [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).