### PR TITLE
fix: 배포 스크립트 컨테이너 관리 안정화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,9 +83,11 @@ jobs:
           port: 22
           script: |
             sudo docker ps
-            sudo docker rm -f $(docker ps -qa)
+            sudo docker rm -f eatssu-prod || true
+            OLD_PROD_CONTAINERS=$(sudo docker ps -aq --filter ancestor=${{ secrets.DOCKER_REPO }}/eatssu-prod)
+            if [ -n "$OLD_PROD_CONTAINERS" ]; then sudo docker rm -f $OLD_PROD_CONTAINERS; fi
             sudo docker pull ${{ secrets.DOCKER_REPO }}/eatssu-prod
-            sudo docker run -d -p 9000:9000 \
+            sudo docker run -d --name eatssu-prod -p 9000:9000 \
             --log-driver=awslogs \
             --log-opt awslogs-region=ap-northeast-2 \
             --log-opt awslogs-group=prod-ec2-group \
@@ -112,9 +114,11 @@ jobs:
           key: ${{ secrets.DEV_PRIVATE_KEY }}
           script: |
             sudo docker ps
-            sudo docker rm -f $(docker ps -qa)
+            sudo docker rm -f eatssu-dev || true
+            OLD_DEV_CONTAINERS=$(sudo docker ps -aq --filter ancestor=${{ secrets.DOCKER_REPO }}/eatssu-dev)
+            if [ -n "$OLD_DEV_CONTAINERS" ]; then sudo docker rm -f $OLD_DEV_CONTAINERS; fi
             sudo docker pull ${{ secrets.DOCKER_REPO }}/eatssu-dev
-            sudo docker run -d -p 9000:9000 \
+            sudo docker run -d --name eatssu-dev -p 9000:9000 \
             --log-driver=awslogs \
             --log-opt awslogs-region=ap-northeast-2 \
             --log-opt awslogs-group=dev-ec2-group \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,7 +84,8 @@ jobs:
           script: |
             sudo docker ps
             sudo docker rm -f eatssu-prod || true
-            sudo docker ps -q --filter publish=9000 | xargs -r sudo docker rm -f
+            PUBLISHED_CONTAINERS=$(sudo docker ps -q --filter publish=9000)
+            if [ -n "$PUBLISHED_CONTAINERS" ]; then sudo docker rm -f $PUBLISHED_CONTAINERS; fi
             sudo docker pull ${{ secrets.DOCKER_REPO }}/eatssu-prod
             sudo docker run -d --name eatssu-prod --restart unless-stopped -p 9000:9000 \
             --log-driver=awslogs \
@@ -114,7 +115,8 @@ jobs:
           script: |
             sudo docker ps
             sudo docker rm -f eatssu-dev || true
-            sudo docker ps -q --filter publish=9000 | xargs -r sudo docker rm -f
+            PUBLISHED_CONTAINERS=$(sudo docker ps -q --filter publish=9000)
+            if [ -n "$PUBLISHED_CONTAINERS" ]; then sudo docker rm -f $PUBLISHED_CONTAINERS; fi
             sudo docker pull ${{ secrets.DOCKER_REPO }}/eatssu-dev
             sudo docker run -d --name eatssu-dev --restart unless-stopped -p 9000:9000 \
             --log-driver=awslogs \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -84,10 +84,9 @@ jobs:
           script: |
             sudo docker ps
             sudo docker rm -f eatssu-prod || true
-            OLD_PROD_CONTAINERS=$(sudo docker ps -aq --filter ancestor=${{ secrets.DOCKER_REPO }}/eatssu-prod)
-            if [ -n "$OLD_PROD_CONTAINERS" ]; then sudo docker rm -f $OLD_PROD_CONTAINERS; fi
+            sudo docker ps -q --filter publish=9000 | xargs -r sudo docker rm -f
             sudo docker pull ${{ secrets.DOCKER_REPO }}/eatssu-prod
-            sudo docker run -d --name eatssu-prod -p 9000:9000 \
+            sudo docker run -d --name eatssu-prod --restart unless-stopped -p 9000:9000 \
             --log-driver=awslogs \
             --log-opt awslogs-region=ap-northeast-2 \
             --log-opt awslogs-group=prod-ec2-group \
@@ -115,10 +114,9 @@ jobs:
           script: |
             sudo docker ps
             sudo docker rm -f eatssu-dev || true
-            OLD_DEV_CONTAINERS=$(sudo docker ps -aq --filter ancestor=${{ secrets.DOCKER_REPO }}/eatssu-dev)
-            if [ -n "$OLD_DEV_CONTAINERS" ]; then sudo docker rm -f $OLD_DEV_CONTAINERS; fi
+            sudo docker ps -q --filter publish=9000 | xargs -r sudo docker rm -f
             sudo docker pull ${{ secrets.DOCKER_REPO }}/eatssu-dev
-            sudo docker run -d --name eatssu-dev -p 9000:9000 \
+            sudo docker run -d --name eatssu-dev --restart unless-stopped -p 9000:9000 \
             --log-driver=awslogs \
             --log-opt awslogs-region=ap-northeast-2 \
             --log-opt awslogs-group=dev-ec2-group \


### PR DESCRIPTION
## #️⃣ Issue Number

- resolved #368

## 📝 요약(Summary)

- `sudo docker rm -f $(docker ps -qa)` 제거 → 이름 기반(`eatssu-prod` / `eatssu-dev`) 삭제로 변경하여 다른 컨테이너가 함께 종료되는 위험 제거
- 포트(9000) 기반 정리 로직 추가로 이름 없이 떠 있는 레거시 컨테이너도 처리 가능
- `--name eatssu-prod` / `--name eatssu-dev` 옵션 추가로 컨테이너 식별 명확화
- `--restart unless-stopped` 옵션 추가로 EC2 재부팅 또는 Docker daemon 재시작 시 자동 복구

## 💬 공유사항 to 리뷰어

- 포트 기반 레거시 컨테이너 정리 로직(`docker ps -q --filter publish=9000 | xargs -r docker rm -f`)은 이름 없이 떠 있는 기존 컨테이너를 처음 한 번 정리하기 위한 것입니다. 이름 기반 관리가 정착되면 이후 제거를 검토할 수 있습니다.
- `xargs -r`은 GNU xargs 전용 옵션으로, EC2(Ubuntu)에서는 정상 동작합니다.
- 테스트 변경사항 없음

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).