### PR TITLE
fix: 인증 응답 로그 마스킹 처리

### DIFF
--- a/src/main/java/ssu/eatssu/domain/admin/dto/LoginRequest.java
+++ b/src/main/java/ssu/eatssu/domain/admin/dto/LoginRequest.java
@@ -1,4 +1,7 @@
 package ssu.eatssu.domain.admin.dto;
 
-public record LoginRequest(String loginId, String password) {
+import ssu.eatssu.global.log.annotation.LogMask;
+
+public record LoginRequest(String loginId,
+                           @LogMask String password) {
 }

--- a/src/main/java/ssu/eatssu/global/log/ControllerLogAspect.java
+++ b/src/main/java/ssu/eatssu/global/log/ControllerLogAspect.java
@@ -104,7 +104,7 @@ public class ControllerLogAspect {
         }
     }
 
-    private String getResponseLog(String uri, Object result) {
+    String getResponseLog(String uri, Object result) {
         if (isAuthApi(uri)) {
             return RESPONSE_BODY_SKIPPED;
         }
@@ -152,7 +152,7 @@ public class ControllerLogAspect {
         return "unknown";
     }
 
-    private Map<String, Object> toSafeMap(Object arg) {
+    Map<String, Object> toSafeMap(Object arg) {
         Map<String, Object> result = new HashMap<>();
         for (Field field : arg.getClass().getDeclaredFields()) {
             field.setAccessible(true);

--- a/src/main/java/ssu/eatssu/global/log/ControllerLogAspect.java
+++ b/src/main/java/ssu/eatssu/global/log/ControllerLogAspect.java
@@ -31,6 +31,8 @@ import java.util.stream.IntStream;
 @RequiredArgsConstructor
 public class ControllerLogAspect {
 
+    private static final String RESPONSE_BODY_SKIPPED = "[response-body-skipped]";
+
     private final ObjectMapper objectMapper;
     private final SlackErrorNotifier slackErrorNotifier;
 
@@ -87,15 +89,7 @@ public class ControllerLogAspect {
             Object result = joinPoint.proceed();
             long time = System.currentTimeMillis() - start;
 
-            String resultJson;
-            try {
-                resultJson = objectMapper.writeValueAsString(result);
-                if (resultJson.length() > 600) {
-                    resultJson = resultJson.substring(0, 600) + "...(truncated)";
-                }
-            } catch (Exception e) {
-                resultJson = String.valueOf(result);
-            }
+            String resultJson = getResponseLog(uri, result);
 
             log.info("RESPONSE {} {} ({} ms) result={}", method, uri, time, resultJson);
             return result;
@@ -108,6 +102,26 @@ public class ControllerLogAspect {
             slackErrorNotifier.notify(e, method, uri, userId, argsJson);
             throw e;
         }
+    }
+
+    private String getResponseLog(String uri, Object result) {
+        if (isAuthApi(uri)) {
+            return RESPONSE_BODY_SKIPPED;
+        }
+
+        try {
+            String resultJson = objectMapper.writeValueAsString(result);
+            if (resultJson.length() > 600) {
+                return resultJson.substring(0, 600) + "...(truncated)";
+            }
+            return resultJson;
+        } catch (Exception e) {
+            return String.valueOf(result);
+        }
+    }
+
+    private boolean isAuthApi(String uri) {
+        return uri != null && uri.startsWith("/oauths/");
     }
 
     private String getCauseMessage(Throwable e) {

--- a/src/test/java/ssu/eatssu/global/log/ControllerLogAspectTest.java
+++ b/src/test/java/ssu/eatssu/global/log/ControllerLogAspectTest.java
@@ -1,0 +1,68 @@
+package ssu.eatssu.global.log;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import ssu.eatssu.domain.admin.dto.LoginRequest;
+import ssu.eatssu.domain.user.dto.Tokens;
+import ssu.eatssu.global.handler.response.BaseResponse;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ControllerLogAspectTest {
+
+    private final ControllerLogAspect controllerLogAspect = new ControllerLogAspect(new ObjectMapper(), null);
+
+    @Test
+    void shouldSkipResponseBodyForOauthApi() throws Exception {
+        // given
+        BaseResponse<Tokens> response = BaseResponse.success(new Tokens("access-token", "refresh-token"));
+
+        // when
+        String result = invokeGetResponseLog("/oauths/kakao", response);
+
+        // then
+        assertThat(result).isEqualTo("[response-body-skipped]");
+        assertThat(result).doesNotContain("access-token", "refresh-token");
+    }
+
+    @Test
+    void shouldLogResponseBodyForNonOauthApi() throws Exception {
+        // given
+        BaseResponse<String> response = BaseResponse.success("ok");
+
+        // when
+        String result = invokeGetResponseLog("/meals", response);
+
+        // then
+        assertThat(result).contains("ok");
+    }
+
+    @Test
+    void shouldMaskAnnotatedRequestFields() throws Exception {
+        // given
+        LoginRequest request = new LoginRequest("admin", "password");
+
+        // when
+        Map<String, Object> result = invokeToSafeMap(request);
+
+        // then
+        assertThat(result).containsEntry("loginId", "admin");
+        assertThat(result).containsEntry("password", "***");
+    }
+
+    private String invokeGetResponseLog(String uri, Object result) throws Exception {
+        Method method = ControllerLogAspect.class.getDeclaredMethod("getResponseLog", String.class, Object.class);
+        method.setAccessible(true);
+        return (String) method.invoke(controllerLogAspect, uri, result);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> invokeToSafeMap(Object arg) throws Exception {
+        Method method = ControllerLogAspect.class.getDeclaredMethod("toSafeMap", Object.class);
+        method.setAccessible(true);
+        return (Map<String, Object>) method.invoke(controllerLogAspect, arg);
+    }
+}

--- a/src/test/java/ssu/eatssu/global/log/ControllerLogAspectTest.java
+++ b/src/test/java/ssu/eatssu/global/log/ControllerLogAspectTest.java
@@ -6,7 +6,6 @@ import ssu.eatssu.domain.admin.dto.LoginRequest;
 import ssu.eatssu.domain.user.dto.Tokens;
 import ssu.eatssu.global.handler.response.BaseResponse;
 
-import java.lang.reflect.Method;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +20,7 @@ class ControllerLogAspectTest {
         BaseResponse<Tokens> response = BaseResponse.success(new Tokens("access-token", "refresh-token"));
 
         // when
-        String result = invokeGetResponseLog("/oauths/kakao", response);
+        String result = controllerLogAspect.getResponseLog("/oauths/kakao", response);
 
         // then
         assertThat(result).isEqualTo("[response-body-skipped]");
@@ -34,7 +33,7 @@ class ControllerLogAspectTest {
         BaseResponse<String> response = BaseResponse.success("ok");
 
         // when
-        String result = invokeGetResponseLog("/meals", response);
+        String result = controllerLogAspect.getResponseLog("/meals", response);
 
         // then
         assertThat(result).contains("ok");
@@ -46,23 +45,11 @@ class ControllerLogAspectTest {
         LoginRequest request = new LoginRequest("admin", "password");
 
         // when
-        Map<String, Object> result = invokeToSafeMap(request);
+        Map<String, Object> result = controllerLogAspect.toSafeMap(request);
 
         // then
         assertThat(result).containsEntry("loginId", "admin");
         assertThat(result).containsEntry("password", "***");
     }
 
-    private String invokeGetResponseLog(String uri, Object result) throws Exception {
-        Method method = ControllerLogAspect.class.getDeclaredMethod("getResponseLog", String.class, Object.class);
-        method.setAccessible(true);
-        return (String) method.invoke(controllerLogAspect, uri, result);
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> invokeToSafeMap(Object arg) throws Exception {
-        Method method = ControllerLogAspect.class.getDeclaredMethod("toSafeMap", Object.class);
-        method.setAccessible(true);
-        return (Map<String, Object>) method.invoke(controllerLogAspect, arg);
-    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- resolved #371

## 📝 요약(Summary)

- `ControllerLogAspect`의 응답 로깅에서 `/oauths/**` URI에 해당하는 경우 응답 body를 `[response-body-skipped]`로 대체하여 `accessToken`, `refreshToken`이 CloudWatch 로그에 평문으로 남지 않도록 수정
- 어드민 로그인 요청 DTO(`LoginRequest`)의 `password` 필드에 `@LogMask` 추가하여 요청 로그에서도 마스킹 처리
- `getResponseLog()`, `isAuthApi()` 메서드 추출로 응답 로깅 로직을 명시적으로 분리
- `ControllerLogAspectTest` 추가 - 응답 마스킹, 일반 API 로깅, `@LogMask` 동작 검증

## 💬 공유사항 to 리뷰어

- `isAuthApi()`는 현재 `/oauths/`로 시작하는 URI만 체크합니다. 어드민 로그인(`/admin/login`) 응답은 현재 JWT를 반환하지 않으므로 제외했습니다. 향후 어드민에 JWT가 붙는다면 별도 대응이 필요합니다.
- 테스트에서 `RESPONSE_BODY_SKIPPED` 상수를 문자열로 하드코딩하고 있습니다. 상수가 변경될 경우 테스트가 이를 잡지 못할 수 있으므로 검토 부탁드립니다.
- 테스트는 실행하지 않았으므로 CI에서 확인이 필요합니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).