### PR TITLE
feat: Grafana Cloud 모니터링 연동 및 actuator 보안 강화

### DIFF
--- a/src/main/java/ssu/eatssu/domain/auth/infrastructure/SecurityConfig.java
+++ b/src/main/java/ssu/eatssu/domain/auth/infrastructure/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
             "/", "/oauths/kakao", "/oauths/apple", "/menus/**", "/meals/**", "/admin/login", "/oauths/v2/kakao","/oauths/v2/apple",
             "/reviews", "/reviews/menus/**", "/reviews/meals/**", "/v2/reviews/statistics/**",
-            "/v2/reviews/menus/**", "/v2/reviews/meals/**", "/actuator/health", "/error-test/**"
+            "/v2/reviews/menus/**", "/v2/reviews/meals/**", "/actuator/health", "/actuator/prometheus", "/error-test/**"
     };
 
     private static final String[] ADMIN_PAGE_LIST = {

--- a/src/main/java/ssu/eatssu/domain/auth/infrastructure/SecurityConfig.java
+++ b/src/main/java/ssu/eatssu/domain/auth/infrastructure/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
             "/", "/oauths/kakao", "/oauths/apple", "/menus/**", "/meals/**", "/admin/login", "/oauths/v2/kakao","/oauths/v2/apple",
             "/reviews", "/reviews/menus/**", "/reviews/meals/**", "/v2/reviews/statistics/**",
-            "/v2/reviews/menus/**", "/v2/reviews/meals/**", "/actuator/**", "/error-test/**"
+            "/v2/reviews/menus/**", "/v2/reviews/meals/**", "/actuator/health", "/error-test/**"
     };
 
     private static final String[] ADMIN_PAGE_LIST = {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -94,6 +94,10 @@ logging:
     com.zaxxer.hikari: INFO
 
 management:
+  server:
+    port: 9001
+    address: 127.0.0.1
+
   endpoint:
     metrics:
       enabled: true

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -104,3 +104,7 @@ management:
     web:
       exposure:
         include: health, info, metrics, prometheus
+
+  metrics:
+    tags:
+      application: eatssu-dev


### PR DESCRIPTION
## #️⃣ Issue Number

- resolved #376

## 📝 요약(Summary)

- `application-dev.yml`에 management server를 9001 포트 + `127.0.0.1` 바인딩으로 분리하여 actuator 엔드포인트를 외부에서 접근 불가하도록 설정
- `application-dev.yml`에 `management.metrics.tags.application: eatssu-dev` 추가하여 Grafana Cloud 대시보드의 Application 필터가 동작하도록 설정
- `SecurityConfig`에서 `AUTH_WHITELIST`의 `/actuator/**` 를 `/actuator/health`로 축소 (9001 포트 분리로 9000 포트에서 actuator가 동작하지 않으므로 실질적 의미는 없으나 명시적 범위 축소)

## 💬 공유사항 to 리뷰어

- **배포 후 EC2 작업 필요**: 머지 후 dev 배포 완료 시점에 EC2에서 Grafana Alloy config의 scrape 주소를 `localhost:9000` → `localhost:9001`로 변경하고 Alloy를 재시작해야 합니다
- actuator가 9001 포트로 분리되므로, EC2 Security Group에서 9001 포트는 외부에 열지 않아야 합니다 (현재 열려있지 않음)
- 테스트는 별도로 실행하지 않았으며 CI에서 확인이 필요합니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).