### PR TITLE
fix: management 포트 Docker publish 및 바인딩 주소 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,7 +118,7 @@ jobs:
             PUBLISHED_CONTAINERS=$(sudo docker ps -q --filter publish=9000)
             if [ -n "$PUBLISHED_CONTAINERS" ]; then sudo docker rm -f $PUBLISHED_CONTAINERS; fi
             sudo docker pull ${{ secrets.DOCKER_REPO }}/eatssu-dev
-            sudo docker run -d --name eatssu-dev --restart unless-stopped -p 9000:9000 \
+            sudo docker run -d --name eatssu-dev --restart unless-stopped -p 9000:9000 -p 127.0.0.1:9001:9001 \
             --log-driver=awslogs \
             --log-opt awslogs-region=ap-northeast-2 \
             --log-opt awslogs-group=dev-ec2-group \

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -96,7 +96,7 @@ logging:
 management:
   server:
     port: 9001
-    address: 127.0.0.1
+    address: 0.0.0.0
 
   endpoint:
     metrics:


### PR DESCRIPTION
## #️⃣ Issue Number

- resolved #378

## 📝 요약(Summary)

- `application-dev.yml`의 `management.server.address`를 `127.0.0.1` → `0.0.0.0`으로 변경하여 Docker 컨테이너 내부에서 모든 인터페이스에 바인딩되도록 수정
- `deploy.yml` dev 배포 스크립트의 `docker run`에 `-p 127.0.0.1:9001:9001` 추가하여 EC2 호스트의 localhost에서만 9001 포트에 접근 가능하도록 설정
- 위 두 변경으로 Grafana Alloy가 `localhost:9001/actuator/prometheus`를 정상적으로 scrape 가능해짐

## 💬 공유사항 to 리뷰어

- `127.0.0.1:9001:9001`로 publish하여 EC2 외부에서는 9001 포트 접근이 불가하고, EC2 내부(Alloy)에서만 접근 가능합니다
- 머지 후 dev 배포 완료 시점에 EC2에서 Alloy를 재시작해야 합니다 (`sudo systemctl restart alloy`)
- 테스트는 별도로 실행하지 않았으며 CI 및 배포 후 `curl http://127.0.0.1:9001/actuator/prometheus`로 검증이 필요합니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).