### PR TITLE
feat: prod 서버 Grafana Cloud 모니터링 설정 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,7 @@ jobs:
             PUBLISHED_CONTAINERS=$(sudo docker ps -q --filter publish=9000)
             if [ -n "$PUBLISHED_CONTAINERS" ]; then sudo docker rm -f $PUBLISHED_CONTAINERS; fi
             sudo docker pull ${{ secrets.DOCKER_REPO }}/eatssu-prod
-            sudo docker run -d --name eatssu-prod --restart unless-stopped -p 9000:9000 \
+            sudo docker run -d --name eatssu-prod --restart unless-stopped -p 9000:9000 -p 127.0.0.1:9001:9001 \
             --log-driver=awslogs \
             --log-opt awslogs-region=ap-northeast-2 \
             --log-opt awslogs-group=prod-ec2-group \

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -100,6 +100,10 @@ logging:
 
 
 management:
+  server:
+    port: 9001
+    address: 0.0.0.0
+
   endpoint:
     metrics:
       enabled: true
@@ -110,4 +114,8 @@ management:
     web:
       exposure:
         include: health, info, metrics, prometheus
+
+  metrics:
+    tags:
+      application: eatssu-prod
 


### PR DESCRIPTION
resolved #380

## 변경 사항

**`application-prod.yml`**
- management server를 port 9001로 분리 (기존: 앱 포트 9000에 actuator 함께 노출)
- `address: 0.0.0.0` 설정 — Docker 컨테이너 내부에서 EC2 호스트의 포트 포워딩이 동작하도록
- `metrics.tags.application: eatssu-prod` 추가 — Grafana 대시보드에서 dev/prod 필터링 가능

**`.github/workflows/deploy.yml`**
- prod docker run에 `-p 127.0.0.1:9001:9001` 추가
- EC2 루프백에만 바인딩하여 외부 직접 접근 차단, Grafana Alloy만 로컬에서 scrape 가능

## 리뷰어 공유사항

- 이 PR 머지 후 prod EC2에 Grafana Alloy 별도 설치 및 `/etc/alloy/config.alloy` 설정 필요 (dev와 동일한 방식, `application: eatssu-prod` 태그로 수집)
- dev 적용 PR: #377, #379 참고