### PR TITLE
feat: PR 생성 시 테스트 자동 실행하는 CI 워크플로우 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       EATSSU_DB_URL_TEST: jdbc:mysql://localhost:3306/eatssu_test
       EATSSU_DB_USERNAME: root
       EATSSU_DB_PASSWORD: test
-      EATSSU_JWT_SECRET_TEST: 0GJB060nxHJUyrRG0+Igjn+NCHua05qf1Xfy3+Y1ZU2G+d8W9BCdEzHR6/W2pFfvYi4iRElOvTHSwzLnd4WqkA==
       EATSSU_AWS_ACCESS_KEY_DEV: dummy-access-key
       EATSSU_AWS_SECRET_KEY_DEV: dummy-secret-key
       EATSSU_SLACK_TOKEN: dummy-slack-token
@@ -53,6 +52,9 @@ jobs:
 
       - name: gradlew 실행 권한 부여
         run: chmod +x gradlew
+
+      - name: 테스트용 JWT 시크릿 생성
+        run: echo "EATSSU_JWT_SECRET_TEST=$(openssl rand -base64 64 | tr -d '\n')" >> "$GITHUB_ENV"
 
       - name: 테스트 실행
         run: ./gradlew test --no-daemon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,65 @@
+name: EAT-SSU Server PR 테스트 게이트
+
+on:
+  pull_request:
+    branches: [ "develop", "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: eatssu_test
+          MYSQL_ROOT_PASSWORD: test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      EATSSU_DB_URL_TEST: jdbc:mysql://localhost:3306/eatssu_test
+      EATSSU_DB_USERNAME: root
+      EATSSU_DB_PASSWORD: test
+      EATSSU_JWT_SECRET_TEST: 0GJB060nxHJUyrRG0+Igjn+NCHua05qf1Xfy3+Y1ZU2G+d8W9BCdEzHR6/W2pFfvYi4iRElOvTHSwzLnd4WqkA==
+      EATSSU_AWS_ACCESS_KEY_DEV: dummy-access-key
+      EATSSU_AWS_SECRET_KEY_DEV: dummy-secret-key
+      EATSSU_SLACK_TOKEN: dummy-slack-token
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: JDK 17 설치
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Gradle 캐싱
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: gradlew 실행 권한 부여
+        run: chmod +x gradlew
+
+      - name: 테스트 실행
+        run: ./gradlew test --no-daemon
+
+      - name: 테스트 리포트 업로드
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/reports/tests/test


### PR DESCRIPTION
## #️⃣ Issue Number

- resolved #385

## 📝 요약(Summary)

- PR이 `develop`, `main`으로 생성될 때 `./gradlew test`를 자동 실행하는 CI 워크플로우(`.github/workflows/ci.yml`) 추가
- 기존 `deploy.yml`은 빌드 시 `-x test`로 테스트를 완전히 스킵하고 있어, 테스트가 자동으로 실행되는 지점이 전혀 없었음 → 이번 PR로 PR 단계에서의 테스트 게이트 신설
- `application-test.yml`이 실제 MySQL 연결을 요구하므로, GitHub Actions service container로 임시 MySQL 8.0을 띄워 테스트 실행 (health check로 DB 준비 대기)
- JWT 테스트 시크릿은 워크플로우에 하드코딩하지 않고, 매 실행마다 `openssl rand -base64 64`로 생성해 `$GITHUB_ENV`에 주입
- AWS/Slack 관련 값은 테스트 코드에서 실제 외부 호출을 하지 않는 것을 확인했으므로 더미 값으로 대체
- 기존 `deploy.yml`(push 트리거, 빌드+배포)은 변경하지 않고 완전히 별도 워크플로우로 분리

## 💬 공유사항 to 리뷰어

- 로컬에서 동일한 환경(MySQL 8.0 컨테이너 + 동일 env)으로 `./gradlew test`를 미리 실행해 검증했습니다. 84개 중 77개 통과, 나머지 7개는 이 PR과 무관한 기존 버그(`Ratings.of()` NPE, `NicknameValidator` 정규식 버그)로 확인되어 각각 별도 fix 이슈(#387, #388)로 분리했습니다. 즉 이 PR을 머지하면 CI가 곧바로 실패 상태로 뜰 수 있으니, #387/#388이 먼저 머지되거나 병행 진행이 필요합니다.
- Branch protection이 아직 설정되어 있지 않아(확인 완료), 이 CI를 required status check으로 강제하려면 별도로 브랜치 보호 규칙을 추가해야 합니다. 이번 PR 범위에는 포함하지 않았습니다.
- MySQL service container는 `root` 계정을 그대로 사용합니다. CI 한정이라 문제는 없지만, 운영/dev 계정과 권한 차이가 있을 수 있다는 점 참고 바랍니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).