### PR TITLE
test: 닉네임 시작/끝 숫자 허용 스펙에 맞게 NicknameValidatorTest 기대값 수정

### DIFF
--- a/src/test/java/ssu/eatssu/domain/user/util/NicknameValidatorTest.java
+++ b/src/test/java/ssu/eatssu/domain/user/util/NicknameValidatorTest.java
@@ -45,7 +45,9 @@ class NicknameValidatorTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"유효한 닉네임","available nic","가능한-닉네임","유-효-한-닉-네-임","유 효 한 닉 1 2 a","ㅇㅅㅎㅇㅌ","0이름","0test","이름0","test0"})
-    void 유효한_이름을_입력하면_예외가_발생하지_않는다(String input) {
+    void doesNotThrowWhenNicknameIsValid(String input) {
+        // given: parameterized valid nickname input
+
         // when & then
         assertDoesNotThrow(()-> nicknameValidator.validateNickname(input));
     }
@@ -92,7 +94,9 @@ class NicknameValidatorTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"-test"," test"})
-    void 한글_또는_영어로_시작하지_않는_닉네임인_경우_예외가_발생한다(String input) {
+    void throwsExceptionWhenNicknameStartsWithInvalidCharacter(String input) {
+        // given: parameterized nickname starting with a symbol (숫자는 시작 문자로 허용됨)
+
         // when & then
         assertThatThrownBy(()->nicknameValidator.validateNickname(input))
                 .isInstanceOf(BaseException.class)
@@ -102,7 +106,9 @@ class NicknameValidatorTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"test-","test "})
-    void 한글_또는_영어로_끝나지_않는_닉네임인_경우_예외가_발생한다(String input) {
+    void throwsExceptionWhenNicknameEndsWithInvalidCharacter(String input) {
+        // given: parameterized nickname ending with a symbol (숫자는 끝 문자로 허용됨)
+
         // when & then
         assertThatThrownBy(()->nicknameValidator.validateNickname(input))
                 .isInstanceOf(BaseException.class)

--- a/src/test/java/ssu/eatssu/domain/user/util/NicknameValidatorTest.java
+++ b/src/test/java/ssu/eatssu/domain/user/util/NicknameValidatorTest.java
@@ -44,7 +44,7 @@ class NicknameValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"유효한 닉네임","available nic","가능한-닉네임","유-효-한-닉-네-임","유 효 한 닉 1 2 a","ㅇㅅㅎㅇㅌ"})
+    @ValueSource(strings = {"유효한 닉네임","available nic","가능한-닉네임","유-효-한-닉-네-임","유 효 한 닉 1 2 a","ㅇㅅㅎㅇㅌ","0이름","0test","이름0","test0"})
     void 유효한_이름을_입력하면_예외가_발생하지_않는다(String input) {
         // when & then
         assertDoesNotThrow(()-> nicknameValidator.validateNickname(input));
@@ -91,7 +91,7 @@ class NicknameValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"0이름","0test","-test"," test"})
+    @ValueSource(strings = {"-test"," test"})
     void 한글_또는_영어로_시작하지_않는_닉네임인_경우_예외가_발생한다(String input) {
         // when & then
         assertThatThrownBy(()->nicknameValidator.validateNickname(input))
@@ -101,7 +101,7 @@ class NicknameValidatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"이름0","test0","test-","test "})
+    @ValueSource(strings = {"test-","test "})
     void 한글_또는_영어로_끝나지_않는_닉네임인_경우_예외가_발생한다(String input) {
         // when & then
         assertThatThrownBy(()->nicknameValidator.validateNickname(input))


### PR DESCRIPTION
## #️⃣ Issue Number

- resolved #388

## 📝 요약(Summary)

- `NicknameValidatorTest`에서 숫자로 시작/끝나는 닉네임(`0이름`, `0test`, `이름0`, `test0`)을 예외 발생 케이스로 잘못 기대하고 있던 테스트를 수정
- `NicknameValidator`의 정규식(프로덕션 코드)은 수정하지 않음 — `BaseResponseStatus.INVALID_START_OF_NICKNAME`/`INVALID_END_OF_NICKNAME`의 실제 사용자 노출 메시지("첫/마지막 글자는 한글, 영문, 숫자만 사용할 수 있습니다")에 숫자가 명시적으로 허용 문자로 포함되어 있어, 실제 버그는 정규식이 아니라 테스트의 기대값이 스펙과 어긋나 있던 것으로 확인됨
- 해당 4개 케이스를 "예외가 발생한다" 파라미터에서 제거하고, "유효한_이름을_입력하면_예외가_발생하지_않는다" 테스트의 파라미터로 이동

## 💬 공유사항 to 리뷰어

- 프로덕션 코드(`NicknameValidator.java`)는 변경하지 않았습니다. 판단 근거는 `BaseResponseStatus`에 이미 정의된 사용자 노출 에러 메시지 텍스트이며, 혹시 그 메시지 자체가 잘못 작성된 것이고 실제로는 숫자 시작/끝을 막아야 하는 게 맞다면 반대 방향(정규식 수정)으로 다시 논의가 필요합니다.
- 로컬에서 `./gradlew test`로 전체 스위트(84개) 통과 확인했습니다. `#387`(Ratings NPE) 수정이 이미 develop에 반영된 상태에서 검증했고, 이번 수정으로 나머지 4건도 모두 통과해 현재 develop 기준 전체 테스트가 그린 상태입니다.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).