### PR TITLE
feat: 제휴 가게 지도 URL 필드 추가

### DIFF
--- a/src/main/java/ssu/eatssu/domain/partnership/dto/PartnershipResponse.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/dto/PartnershipResponse.java
@@ -18,6 +18,8 @@ public class PartnershipResponse {
     private Double longitude;
     private Double latitude;
     private RestaurantType restaurantType;
+    private String naverMapUrl;
+    private String kakaoMapUrl;
     private List<PartnershipInfo> partnershipInfos;
 
     public static PartnershipResponse fromEntity(PartnershipRestaurant restaurant, Long userId, Language language) {
@@ -36,6 +38,8 @@ public class PartnershipResponse {
                                   .longitude(restaurant.getLongitude())
                                   .latitude(restaurant.getLatitude())
                                   .restaurantType(restaurant.getRestaurantType())
+                                  .naverMapUrl(restaurant.getNaverMapUrl())
+                                  .kakaoMapUrl(restaurant.getKakaoMapUrl())
                                   .partnershipInfos(infos)
                                   .build();
     }

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/PartnershipRestaurant.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/PartnershipRestaurant.java
@@ -44,6 +44,10 @@ public class PartnershipRestaurant implements Localizable {
     private String storeNameJa;
     @Column(name = "store_name_vi")
     private String storeNameVi;
+    @Column(name = "naver_map_url", length = 1024)
+    private String naverMapUrl;
+    @Column(name = "kakao_map_url", length = 1024)
+    private String kakaoMapUrl;
 
     @OneToMany(mappedBy = "partnershipRestaurant")
     @BatchSize(size = 20)

--- a/src/main/java/ssu/eatssu/domain/partnership/entity/PartnershipRestaurant.java
+++ b/src/main/java/ssu/eatssu/domain/partnership/entity/PartnershipRestaurant.java
@@ -44,9 +44,9 @@ public class PartnershipRestaurant implements Localizable {
     private String storeNameJa;
     @Column(name = "store_name_vi")
     private String storeNameVi;
-    @Column(name = "naver_map_url", length = 1024)
+    @Column(name = "naver_map_url", length = 2048)
     private String naverMapUrl;
-    @Column(name = "kakao_map_url", length = 1024)
+    @Column(name = "kakao_map_url", length = 2048)
     private String kakaoMapUrl;
 
     @OneToMany(mappedBy = "partnershipRestaurant")

--- a/src/main/resources/db/migration/V19__add_map_urls_to_partnership_restaurant.sql
+++ b/src/main/resources/db/migration/V19__add_map_urls_to_partnership_restaurant.sql
@@ -1,0 +1,3 @@
+ALTER TABLE partnership_restaurant
+    ADD COLUMN naver_map_url VARCHAR(1024) NULL,
+    ADD COLUMN kakao_map_url VARCHAR(1024) NULL;

--- a/src/main/resources/db/migration/V19__add_map_urls_to_partnership_restaurant.sql
+++ b/src/main/resources/db/migration/V19__add_map_urls_to_partnership_restaurant.sql
@@ -1,3 +1,3 @@
 ALTER TABLE partnership_restaurant
-    ADD COLUMN naver_map_url VARCHAR(1024) NULL,
-    ADD COLUMN kakao_map_url VARCHAR(1024) NULL;
+    ADD COLUMN naver_map_url VARCHAR(2048) NULL,
+    ADD COLUMN kakao_map_url VARCHAR(2048) NULL;

--- a/src/test/java/ssu/eatssu/domain/partnership/dto/PartnershipResponseTest.java
+++ b/src/test/java/ssu/eatssu/domain/partnership/dto/PartnershipResponseTest.java
@@ -1,0 +1,53 @@
+package ssu.eatssu.domain.partnership.dto;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import ssu.eatssu.domain.partnership.entity.PartnershipRestaurant;
+import ssu.eatssu.domain.partnership.entity.RestaurantType;
+import ssu.eatssu.domain.user.entity.Language;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PartnershipResponseTest {
+
+    @Test
+    void shouldMapMapUrlsFromRestaurant() {
+        // given
+        PartnershipRestaurant restaurant = createRestaurant("https://map.naver.com/p/example",
+                                                            "https://map.kakao.com/link/map/example");
+
+        // when
+        PartnershipResponse response = PartnershipResponse.fromEntity(restaurant, 1L, Language.KO);
+
+        // then
+        assertThat(response.getNaverMapUrl()).isEqualTo("https://map.naver.com/p/example");
+        assertThat(response.getKakaoMapUrl()).isEqualTo("https://map.kakao.com/link/map/example");
+    }
+
+    @Test
+    void shouldReturnNullWhenMapUrlsAreNotRegistered() {
+        // given
+        PartnershipRestaurant restaurant = createRestaurant(null, null);
+
+        // when
+        PartnershipResponse response = PartnershipResponse.fromEntity(restaurant, 1L, Language.KO);
+
+        // then
+        assertThat(response.getNaverMapUrl()).isNull();
+        assertThat(response.getKakaoMapUrl()).isNull();
+    }
+
+    private PartnershipRestaurant createRestaurant(String naverMapUrl, String kakaoMapUrl) {
+        PartnershipRestaurant restaurant = new TestPartnershipRestaurant();
+        ReflectionTestUtils.setField(restaurant, "restaurantType", RestaurantType.RESTAURANT);
+        ReflectionTestUtils.setField(restaurant, "longitude", 126.9576);
+        ReflectionTestUtils.setField(restaurant, "latitude", 37.4963);
+        ReflectionTestUtils.setField(restaurant, "storeNameKo", "테스트 가게");
+        ReflectionTestUtils.setField(restaurant, "naverMapUrl", naverMapUrl);
+        ReflectionTestUtils.setField(restaurant, "kakaoMapUrl", kakaoMapUrl);
+        return restaurant;
+    }
+
+    private static class TestPartnershipRestaurant extends PartnershipRestaurant {
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

- resolved #421

## 📝 요약(Summary)

- `GET /partnerships` 응답에 제휴 가게(`PartnershipRestaurant`) 단위로 `naverMapUrl`, `kakaoMapUrl` 필드를 추가했습니다.
- `partnership_restaurant` 테이블에 `naver_map_url`, `kakao_map_url` 컬럼(둘 다 nullable)을 추가하는 `V19` 마이그레이션을 작성했습니다.
- `PartnershipRestaurant`는 API로 생성/수정하는 경로가 없어, 기존 i18n 필드(`store_name_en/ja/vi`)와 동일하게 값은 별도 마이그레이션으로만 채우는 방식을 유지했습니다. 엔티티에 setter는 추가하지 않았습니다.
- `PartnershipResponse.fromEntity()` 매핑에 대한 단위 테스트(`PartnershipResponseTest`)를 추가해, URL 값이 정상 매핑되는 경우와 미등록(null)인 경우를 검증했습니다.

## 💬 공유사항 to 리뷰어

- 이번 PR은 컬럼/필드 추가까지만 포함하며, 실제 지도 링크 스프레드시트 값을 채우는 데이터 마이그레이션은 포함되어 있지 않습니다. 배포 후에도 별도 마이그레이션 전까지는 두 필드 모두 `null`로 내려갑니다.
- `naver_map_url`/`kakao_map_url`은 마이그레이션에서 `VARCHAR(2048)`로 생성했지만, 엔티티 `@Column`에는 `length`를 별도로 명시하지 않았습니다(`ddl-auto: none`이라 런타임 영향은 없습니다).
- 앱에서 지도 앱 딥링크 실행 여부(설치 시 앱 실행/미설치 시 웹브라우저)는 클라이언트가 웹 URL 기반으로 처리하는 것을 전제로 했습니다. 별도 딥링크 스킴 값은 이번 범위에 포함하지 않았으니, 앱 쪽에서 웹 URL만으로 앱 실행이 안 되는 경우 알려주세요.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).