### PR TITLE
fix: actuator/health 메인 포트 404 응답 수정

### DIFF
--- a/src/main/java/ssu/eatssu/global/handler/HealthCheckController.java
+++ b/src/main/java/ssu/eatssu/global/handler/HealthCheckController.java
@@ -1,0 +1,14 @@
+package ssu.eatssu.global.handler;
+
+import java.util.Map;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/actuator/health")
+    public Map<String, String> health() {
+        return Map.of("status", "UP");
+    }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

- resolved #423

## 📝 요약(Summary)

- dev/prod 공개 도메인에서 `GET /actuator/health` 요청 시 404가 발생하는 문제를 수정
- 원인: `management.server.port: 9001` 설정으로 actuator가 메인 서버(9000)와 분리된 별도 관리 포트에서 서빙되고 있고, Docker 컨테이너에서도 9001은 `127.0.0.1`에만 바인딩되어 있어 공개 도메인(9000)으로는 `/actuator/**` 경로 자체가 존재하지 않음
- `management.endpoint.health.additional-path` 설정으로 해결하려 했으나 해당 기능은 Spring Boot 3.1+ 전용이며 본 프로젝트는 3.0.4를 사용 중이라 적용되지 않아, 대신 `global/handler/HealthCheckController`를 신규 추가해 메인 서버 포트(9000)에서 `GET /actuator/health`가 `{"status":"UP"}`을 응답하도록 함
- 9001 관리 포트의 실제 actuator(`/actuator/prometheus`, `/actuator/metrics`)는 그대로 유지되어 Grafana Cloud 모니터링 연동에는 영향 없음
- `SecurityConfig`/`JwtAuthenticationFilter`의 화이트리스트에는 이미 `/actuator/health`가 등록되어 있어 별도 보안 설정 변경없음

## 💬 공유사항 to 리뷰어

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).