### PR TITLE
feat: 로그인 성공/실패 Micrometer 카운터 추가

### DIFF
--- a/src/main/java/ssu/eatssu/domain/auth/service/OAuthService.java
+++ b/src/main/java/ssu/eatssu/domain/auth/service/OAuthService.java
@@ -19,6 +19,7 @@ import ssu.eatssu.domain.auth.dto.request.AppleLoginRequestV2;
 import ssu.eatssu.domain.auth.dto.request.KakaoLoginRequestV2;
 
 import ssu.eatssu.domain.user.entity.User;
+import ssu.eatssu.domain.user.entity.DeviceType;
 import ssu.eatssu.domain.auth.entity.OAuthProvider;
 import ssu.eatssu.domain.auth.entity.AppleAuthenticator;
 import ssu.eatssu.domain.auth.security.JwtTokenProvider;
@@ -56,10 +57,7 @@ public class OAuthService {
      */
     public Tokens kakaoLoginV2(KakaoLoginRequestV2 request) {
         try {
-            User user = userRepository.findByProviderId(request.providerId())
-                    .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(request.email())
-                            .orElseGet(() -> userService.joinV2(request.email(), KAKAO, request.providerId(), request.deviceType())));
-
+            User user = findOrCreateUser(request.email(), KAKAO, request.providerId(), request.deviceType());
             user.updateDeviceType(request.deviceType());
 
             Tokens tokens = generateOauthJwtTokens(user.getEmail(), user.getProvider(), user.getProviderId());
@@ -91,9 +89,7 @@ public class OAuthService {
         try {
             OAuthInfo oAuthInfo = appleAuthenticator.getOAuthInfoByIdentityToken(request.identityToken());
 
-            User user = userRepository.findByProviderId(oAuthInfo.providerId())
-                    .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(oAuthInfo.email())
-                            .orElseGet(() -> userService.joinV2(oAuthInfo.email(), APPLE, oAuthInfo.providerId(), request.deviceType())));
+            User user = findOrCreateUser(oAuthInfo.email(), APPLE, oAuthInfo.providerId(), request.deviceType());
 
             updateAppleUserEmail(user, oAuthInfo.email());
 
@@ -156,5 +152,11 @@ public class OAuthService {
 
     private void countLoginAttempt(String provider, String result) {
         meterRegistry.counter("login.attempts", "provider", provider, "result", result).increment();
+    }
+
+    private User findOrCreateUser(String email, OAuthProvider provider, String providerId, DeviceType deviceType) {
+        return userRepository.findByProviderId(providerId)
+                .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(email)
+                        .orElseGet(() -> userService.joinV2(email, provider, providerId, deviceType)));
     }
 }

--- a/src/main/java/ssu/eatssu/domain/auth/service/OAuthService.java
+++ b/src/main/java/ssu/eatssu/domain/auth/service/OAuthService.java
@@ -1,26 +1,31 @@
 package ssu.eatssu.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.springframework.security.core.Authentication;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import ssu.eatssu.domain.auth.dto.OAuthInfo;
-import ssu.eatssu.domain.auth.dto.request.AppleLoginRequest;
-import ssu.eatssu.domain.auth.dto.request.AppleLoginRequestV2;
-import ssu.eatssu.domain.auth.dto.request.KakaoLoginRequest;
-import ssu.eatssu.domain.auth.dto.request.KakaoLoginRequestV2;
-import ssu.eatssu.domain.auth.dto.request.ValidRequest;
-import ssu.eatssu.domain.auth.entity.AppleAuthenticator;
-import ssu.eatssu.domain.auth.entity.OAuthProvider;
-import ssu.eatssu.domain.auth.security.JwtTokenProvider;
-import ssu.eatssu.domain.auth.util.RandomNicknameUtil;
 import ssu.eatssu.domain.user.dto.response.Tokens;
-import ssu.eatssu.domain.user.entity.DeviceType;
+import ssu.eatssu.domain.auth.dto.request.ValidRequest;
+import ssu.eatssu.domain.auth.dto.request.AppleLoginRequest;
+import ssu.eatssu.domain.auth.dto.request.KakaoLoginRequest;
+import ssu.eatssu.domain.auth.dto.request.AppleLoginRequestV2;
+import ssu.eatssu.domain.auth.dto.request.KakaoLoginRequestV2;
+
 import ssu.eatssu.domain.user.entity.User;
-import ssu.eatssu.domain.user.repository.UserRepository;
+import ssu.eatssu.domain.auth.entity.OAuthProvider;
+import ssu.eatssu.domain.auth.entity.AppleAuthenticator;
+import ssu.eatssu.domain.auth.security.JwtTokenProvider;
+
 import ssu.eatssu.domain.user.service.UserService;
+import ssu.eatssu.domain.user.repository.UserRepository;
+
 import ssu.eatssu.global.handler.response.BaseException;
 
 import static ssu.eatssu.domain.auth.entity.OAuthProvider.APPLE;
@@ -32,6 +37,7 @@ import static ssu.eatssu.domain.auth.entity.OAuthProvider.KAKAO;
 public class OAuthService {
 
     private final UserService userService;
+    private final MeterRegistry meterRegistry;
     private final UserRepository userRepository;
     private final AppleAuthenticator appleAuthenticator;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
@@ -49,14 +55,20 @@ public class OAuthService {
      * V1 -> V2로 넘어가면서 DeviceType(IOS,ANDROID) 정보를 추가로 받게 되었고, 기존에 가입한 유저들은 추가로 기입해 주게 됩니다.
      */
     public Tokens kakaoLoginV2(KakaoLoginRequestV2 request) {
-        User user = userRepository.findByProviderId(request.providerId())
-                .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(request.email())
-                        .orElseGet(() -> userService.joinV2(request.email(), KAKAO, request.providerId(),request.deviceType())));
+        try {
+            User user = userRepository.findByProviderId(request.providerId())
+                    .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(request.email())
+                            .orElseGet(() -> userService.joinV2(request.email(), KAKAO, request.providerId(), request.deviceType())));
 
-        user.updateDeviceType(request.deviceType());
+            user.updateDeviceType(request.deviceType());
 
-
-        return generateOauthJwtTokens(user.getEmail(), user.getProvider(), user.getProviderId());
+            Tokens tokens = generateOauthJwtTokens(user.getEmail(), user.getProvider(), user.getProviderId());
+            countLoginAttempt("kakao", "success");
+            return tokens;
+        } catch (Exception e) {
+            countLoginAttempt("kakao", "fail");
+            throw e;
+        }
     }
 
 
@@ -76,17 +88,24 @@ public class OAuthService {
      * V1 -> V2로 넘어가면서 DeviceType(IOS,ANDROID) 정보를 추가로 받게 되었고, 기존에 가입한 유저들은 추가로 기입해 주게 됩니다.
      */
     public Tokens appleLoginV2(AppleLoginRequestV2 request) {
-        OAuthInfo oAuthInfo = appleAuthenticator.getOAuthInfoByIdentityToken(request.identityToken());
+        try {
+            OAuthInfo oAuthInfo = appleAuthenticator.getOAuthInfoByIdentityToken(request.identityToken());
 
-        User user = userRepository.findByProviderId(oAuthInfo.providerId())
-                .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(oAuthInfo.email())
-                        .orElseGet(() -> userService.joinV2(oAuthInfo.email(), APPLE, oAuthInfo.providerId(),request.deviceType())));
+            User user = userRepository.findByProviderId(oAuthInfo.providerId())
+                    .orElseGet(() -> userRepository.findFirstByEmailOrderByIdAsc(oAuthInfo.email())
+                            .orElseGet(() -> userService.joinV2(oAuthInfo.email(), APPLE, oAuthInfo.providerId(), request.deviceType())));
 
-        updateAppleUserEmail(user, oAuthInfo.email());
+            updateAppleUserEmail(user, oAuthInfo.email());
 
-        user.updateDeviceType(request.deviceType());
+            user.updateDeviceType(request.deviceType());
 
-        return generateOauthJwtTokens(user.getEmail(), user.getProvider(), user.getProviderId());
+            Tokens tokens = generateOauthJwtTokens(user.getEmail(), user.getProvider(), user.getProviderId());
+            countLoginAttempt("apple", "success");
+            return tokens;
+        } catch (Exception e) {
+            countLoginAttempt("apple", "fail");
+            throw e;
+        }
     }
 
     public Tokens refreshTokens(Authentication authentication) {
@@ -133,5 +152,9 @@ public class OAuthService {
 
     private String makeOauthCredentials(OAuthProvider provider, String providerId) {
         return provider + providerId;
+    }
+
+    private void countLoginAttempt(String provider, String result) {
+        meterRegistry.counter("login.attempts", "provider", provider, "result", result).increment();
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

- resolved #431

## 📝 요약(Summary)

- 카카오/애플 로그인(V2) 성공·실패를 Micrometer `Counter`로 계측함. `login.attempts{provider="kakao|apple", result="success|fail"}` 형태로 `/actuator/prometheus`에 노출됨.
- `OAuthService`에 `MeterRegistry`를 주입하고, `kakaoLoginV2`/`appleLoginV2`를 try/catch로 감싸서 성공 시 정상 반환 직전에, 예외 발생 시 catch에서 카운트를 증가시킴. 원래 예외는 그대로 rethrow하니까 기존 에러 처리 흐름은 안 바뀜.
- V1(`kakaoLogin`/`appleLogin`)은 계측 대상에서 뺐음 — 배포된 인스턴스에서 약 1개월간 V1 요청이 0건으로 확인돼서 사실상 죽은 트래픽이고, `.claude/rules/auth.md`에도 V1은 마이그레이션 후 삭제 예정으로 명시돼 있음.
- `kakaoLoginV2`/`appleLoginV2`에 중복돼 있던 "provider로 유저 조회 후 없으면 가입" 로직을 `findOrCreateUser` private 메서드로 뽑아서 정리함.

## 💬 공유사항 to 리뷰어

- 카디널리티 관리하려고 태그는 `provider`, `result` 2개로만 최소화함. 신규가입 여부 구분, 세부 에러코드 태그 같은 건 이번 범위에서 제외(필요하면 나중에 확장).
- `catch (Exception e)`로 넓게 잡은 이유는, `generateOauthJwtTokens` 내부의 `AuthenticationManagerBuilder.authenticate()`가 `BaseException`이 아니라 Spring Security의 `AuthenticationException` 계열을 던질 수 있어서, 이 케이스도 로그인 실패로 정확히 잡기 위함
- 배포하고 나서 `/actuator/prometheus`에서 `login_attempts_total{...}` 지표 잘 뜨는지 한 번 확인 필요함.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).