### PR TITLE
[feat] 베트남어 일본어 번역 추가

### DIFF
--- a/src/main/java/ssu/eatssu/domain/review/presentation/docs/ReviewControllerV2Docs.java
+++ b/src/main/java/ssu/eatssu/domain/review/presentation/docs/ReviewControllerV2Docs.java
@@ -96,7 +96,7 @@ public interface ReviewControllerV2Docs {
     @Operation(summary = "리뷰 번역", description = """
             리뷰 내용을 DeepL로 번역하는 API 입니다.<br><br>
             같은 리뷰/언어 조합은 캐시된 결과를 반환합니다.<br><br>
-            현재는 language=EN만 지원합니다.
+            현재는 language=EN/JA/VI만 지원합니다.
             """)
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "리뷰 번역 성공"),
@@ -107,7 +107,7 @@ public interface ReviewControllerV2Docs {
     })
     BaseResponse<ReviewTranslationResponse> translateReview(
             @Parameter(description = "reviewId") Long reviewId,
-            @Parameter(description = "번역 대상 언어(현재 EN만 지원)") Language language);
+            @Parameter(description = "번역 대상 언어(현재 EN/JA/VI만 지원)") Language language);
 
     @Operation(summary = "식단(변동 메뉴) 리뷰 정보 조회 V2(메뉴명, 평점 등등) [인증 토큰 필요 X]", description = """
             식단 리뷰 정보를 조회하는 API 입니다.<br><br>

--- a/src/main/java/ssu/eatssu/domain/review/service/ReviewTranslationService.java
+++ b/src/main/java/ssu/eatssu/domain/review/service/ReviewTranslationService.java
@@ -1,6 +1,8 @@
 package ssu.eatssu.domain.review.service;
 
+import java.util.EnumSet;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -23,13 +25,16 @@ import static ssu.eatssu.global.handler.response.BaseResponseStatus.NOT_FOUND_RE
 @Service
 public class ReviewTranslationService {
 
+    private static final Set<Language> SUPPORTED_TARGET_LANGUAGES = EnumSet.of(Language.EN, Language.JA,
+            Language.VI);
+
     private final ReviewRepository reviewRepository;
     private final ReviewTranslationRepository reviewTranslationRepository;
     private final DeepLTranslationClient deeplTranslationClient;
     private final TransactionTemplate transactionTemplate;
 
     public ReviewTranslationResponse translateReview(Long reviewId, Language language) {
-        if (language != Language.EN) {
+        if (!SUPPORTED_TARGET_LANGUAGES.contains(language)) {
             throw new BaseException(FAILED_VALIDATION);
         }
 


### PR DESCRIPTION
## #️⃣ Issue Number


- resolved #434 
## 📝 요약(Summary)

  - 리뷰 번역 API(`POST /reviews/{reviewId}/translate`)가 영어(EN)만 지원하던 것을 일본어(JA), 베트남어(VI)까지 지원하도록 확장
  - `ReviewTranslationService`의 언어 검증 로직을 `language != EN` 방식에서 `EnumSet.of(EN, JA, VI)` 허용 목록 방식으로 변경 (원문 언어인 KO는 계속 거부)
  - DeepL 호출/캐시 저장 로직은 이미 언어 무관하게 구현되어 있어 별도 수정 없이 그대로 재사용됨
  - Swagger 문서(`ReviewControllerV2Docs`) 설명 문구를 EN/JA/VI 지원으로 갱신

## 💬 공유사항 to 리뷰어


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
